### PR TITLE
Import script from govuk-guix

### DIFF
--- a/govuk-connect
+++ b/govuk-connect
@@ -383,19 +383,6 @@ def govuk_directory
   File.dirname(File.dirname(File.dirname(__FILE__)))
 end
 
-def govuk_developer_docs_applications_data
-  log 'debug: fetching the govuk-developer-docs application data'
-
-  applications_yml_file = File.join(
-    govuk_directory,
-    'govuk-developer-docs',
-    'data',
-    'applications.yml'
-  )
-
-  YAML::load_file(applications_yml_file)
-end
-
 def govuk_puppet_node_class_data(environment, hosting)
   log "debug: fetching govuk-puppet node class data for #{hosting} #{environment}"
 

--- a/govuk-connect
+++ b/govuk-connect
@@ -877,6 +877,8 @@ def main
     TYPES.keys.each do |x|
       STDERR.puts " - #{x}"
     end
+    STDERR.puts
+    STDERR.puts EXAMPLES
 
     exit 1
   end
@@ -890,6 +892,9 @@ def main
     TYPES.keys.each do |x|
       STDERR.puts " - #{x}"
     end
+    STDERR.puts
+    STDERR.puts EXAMPLES
+
     exit 1
   end
 

--- a/govuk-connect
+++ b/govuk-connect
@@ -321,11 +321,23 @@ def node_class_for_app(app_name, environment, hosting)
   app_lookup_hash = {}
   node_class_data.each do |node_class, data|
     data['apps'].each do |app|
-      app_lookup_hash[app] = node_class
+      if app_lookup_hash.key? app
+        app_lookup_hash[app] += [node_class]
+      else
+        app_lookup_hash[app] = [node_class]
+      end
     end
   end
 
-  node_class = app_lookup_hash[app_name]
+  node_classes = app_lookup_hash[app_name]
+
+  if node_classes.length > 1
+    error "error: ambiguous node class for #{app_name} in #{environment}"
+
+    exit 1
+  else
+    node_class = node_classes.first
+  end
 
   log "debug: node class: #{node_class}"
 
@@ -427,27 +439,25 @@ def hosting_for_app(app_name, environment)
 end
 
 def govuk_app_command(target, environment, command)
-  hosting, name, number = parse_hosting_name_and_number(target)
+  node_class, app_name, number = parse_node_class_app_name_and_number(target)
 
-  info "Connecting to the app #{command} for #{bold(name)},\
+  info "Connecting to the app #{command} for #{bold(app_name)},\
  in the #{bold(environment)} environment"
 
-  if hosting
-    info "The selected hosting provider is #{bold(hosting)}"
-  else
-    hosting = hosting_for_app(name, environment)
+  hosting = hosting_for_app(app_name, environment)
 
-    info "The relevant hosting provider is #{bold(hosting)}"
-  end
-
-  node_class = node_class_for_app(
-    name,
-    environment,
-    hosting
-  )
+  info "The relevant hosting provider is #{bold(hosting)}"
 
   unless node_class
-    error "error: application '#{name}' not found."
+    node_class = node_class_for_app(
+      app_name,
+      environment,
+      hosting
+    )
+  end
+
+  unless node_class
+    error "error: application '#{app_name}' not found."
     newline
 
     application_names = application_names_from_node_class_data(
@@ -455,7 +465,7 @@ def govuk_app_command(target, environment, command)
       hosting
     )
 
-    similar_application_names = strings_similar_to(name, application_names)
+    similar_application_names = strings_similar_to(app_name, application_names)
     if similar_application_names.any?
       info "did you mean:"
       similar_application_names.each { |s| info " - #{s}" }
@@ -478,7 +488,7 @@ def govuk_app_command(target, environment, command)
       number: number
     },
     environment,
-    command: "govuk_app_#{command} #{name}"
+    command: "govuk_app_#{command} #{app_name}"
   )
 end
 
@@ -698,6 +708,33 @@ def parse_hosting_name_and_number(target)
   log "debug: hosting: #{hosting.inspect}, name: #{name.inspect}, number: #{number.inspect}"
 
   return hosting, name, number
+end
+
+def parse_node_class_app_name_and_number(target)
+  log "debug: parsing target: #{target}"
+  if target.is_a? Hash
+    return %i[node_class app_name number].map do |key|
+      target[key]
+    end
+  end
+
+  if target.include? '/'
+    node_class, app_name_and_number = target.split '/'
+  else
+    app_name_and_number = target
+  end
+
+  if app_name_and_number.include? ':'
+    app_name, number = name_and_number.split ':'
+
+    number = number.to_i
+  else
+    app_name = app_name_and_number
+  end
+
+  log "debug: node_class: #{node_class.inspect}, app_name: #{app_name.inspect}, number: #{number.inspect}"
+
+  return node_class, app_name, number
 end
 
 def check_for_target(target)

--- a/govuk-connect
+++ b/govuk-connect
@@ -211,6 +211,24 @@ def strings_similar_to(target, strings)
   end
 end
 
+def check_ruby_version_greater_than(required_major:, required_minor:)
+  major, minor = RUBY_VERSION.split '.'
+
+  insufficient_version = (
+    major.to_i < required_major || (
+      major.to_i == required_major &&
+      minor.to_i < required_minor
+    )
+  )
+
+  if insufficient_version
+    error "insufficient Ruby version: #{RUBY_VERSION}"
+    error "must be at least #{required_major}.#{required_minor}"
+
+    exit 1
+  end
+end
+
 def port_free?(port)
   # No idea how well this works, but it's hopefully better than nothing
 
@@ -974,6 +992,7 @@ TYPES = {
 
 def main
   system('govuk check-for-govuk-guix-updates')
+  check_ruby_version_greater_than(required_major: 2, required_minor: 0)
 
   double_dash_index = ARGV.index '--'
   if double_dash_index

--- a/govuk-connect
+++ b/govuk-connect
@@ -1002,6 +1002,7 @@ def main
       STDERR.puts " - #{x}"
     end
     STDERR.puts
+    STDERR.puts "Example commands:"
     STDERR.puts EXAMPLES
 
     exit 1
@@ -1017,6 +1018,7 @@ def main
       STDERR.puts " - #{x}"
     end
     STDERR.puts
+    STDERR.puts "Example commands:"
     STDERR.puts EXAMPLES
 
     exit 1

--- a/govuk-connect
+++ b/govuk-connect
@@ -558,31 +558,30 @@ def hosting_for_app(app_name, environment)
     return hosting
   end
 
-  app_data = govuk_developer_docs_applications_data.find do |data|
-    key = (data.key? 'puppet_name') ? 'puppet_name' : 'github_repo_name'
+  aws_app_names = application_names_from_node_class_data(
+    environment,
+    :aws,
+  )
 
-    data[key] == app_name
-  end
-
-  unless app_data
-    error "error: unknown hosting for #{app_name} in #{environment}"
-    exit 1
-  end
-
-  hosting = app_data['production_hosted_on']
-
-  if hosting == 'aws'
+  if aws_app_names.include? app_name
     log "debug: #{app_name} is hosted in AWS"
 
-    :aws
-  elsif hosting == 'carrenza'
+    return :aws
+  end
+
+  carrenza_app_names = application_names_from_node_class_data(
+    environment,
+    :carrenza,
+  )
+
+  if carrenza_app_names.include? app_name
     log "debug: #{app_name} is hosted in Carrenza"
 
-    :carrenza
-  else
-    error "error: unknown hosting value '#{hosting}' for #{app_name}"
-    exit 1
+    return :carrenza
   end
+
+  error "error: unknown hosting value '#{hosting}' for #{app_name}"
+  exit 1
 end
 
 def govuk_app_command(target, environment, command)

--- a/govuk-connect
+++ b/govuk-connect
@@ -186,6 +186,20 @@ def ssh_username
   end
 end
 
+def ssh_identity_file
+  @ssh_identity_file ||= begin
+    YAML::load_file(config_file)['ssh_identity_file'] if File.exist? config_file
+  end
+end
+
+def ssh_identity_arguments
+  if ssh_identity_file
+    ['-i', ssh_identity_file]
+  else
+    []
+  end
+end
+
 def user_at_host(user, host)
   "#{user}@#{host}"
 end
@@ -195,6 +209,7 @@ def govuk_node_list_classes(environment, hosting)
   command = [
     'ssh',
     '-o', 'ConnectTimeout=2', # Show a failure quickly
+    *ssh_identity_arguments,
     user_at_host(
       ssh_username,
       jumpbox_for_environment_and_hosting(environment, hosting)
@@ -224,6 +239,7 @@ def get_domains_for_node_class(target, environment, hosting, ssh_username)
   command = [
     'ssh',
     '-o', 'ConnectTimeout=2', # Show a failure quickly
+    *ssh_identity_arguments,
     user_at_host(
       ssh_username,
       jumpbox_for_environment_and_hosting(environment, hosting)
@@ -565,6 +581,7 @@ def ssh(
 
   ssh_command = [
     'ssh',
+    *ssh_identity_arguments,
     '-J', user_at_host(
       ssh_username,
       jumpbox_for_environment_and_hosting(environment, hosting)

--- a/govuk-connect
+++ b/govuk-connect
@@ -183,10 +183,7 @@ end
 
 def print_ssh_username_configuration_help
   info "The SSH username used was: #{bold(ssh_username)}"
-  info "Check this is correct, and it it isn't run the following command to set the correct username"
-  newline
-  info "  #{bold('govuk config ssh_username USERNAME')}"
-  newline
+  info "Check this is correct, and if it isn't, set the `USER` environment variable to the correct username."
 end
 
 # From Rosetta Code: https://rosettacode.org/wiki/Levenshtein_distance#Ruby

--- a/govuk-connect
+++ b/govuk-connect
@@ -1,0 +1,743 @@
+#!/usr/bin/env ruby
+
+require 'uri'
+require 'yaml'
+require 'open3'
+require 'socket'
+require 'timeout'
+require 'optparse'
+
+USAGE_BANNER = 'Usage: govuk connect TYPE TARGET [options]'
+
+EXAMPLES = <<~EXAMPLES
+  For example:
+
+    govuk connect app-console --environment staging publishing-api
+
+EXAMPLES
+
+RABBITMQ_PORT = 15672
+SIDEKIQ_MONITORING_PORT = 3211
+
+JUMPBOXES = {
+  ci: {
+    carrenza: 'ci-jumpbox.integration.publishing.service.gov.uk',
+  },
+  integration: {
+    aws: 'jumpbox.integration.publishing.service.gov.uk',
+  },
+  staging: {
+    carrenza: 'jumpbox.staging.publishing.service.gov.uk',
+    aws: 'jumpbox.staging.govuk.digital',
+  },
+  production: {
+    carrenza: 'jumpbox.publishing.service.gov.uk',
+    aws: 'jumpbox.production.govuk.digital',
+  }
+}
+
+def log(message)
+  STDERR.puts message if $verbose
+end
+
+def bold(string)
+  "\e[1m#{string}\e[0m"
+end
+
+def newline
+  STDERR.puts
+end
+
+def info(message)
+  STDERR.puts message
+end
+
+def error(message)
+  STDERR.puts "\e[1m\e[31m#{message}\e[0m"
+end
+
+# From Rosetta Code: https://rosettacode.org/wiki/Levenshtein_distance#Ruby
+def levenshtein_distance(a, b)
+  a, b = a.downcase, b.downcase
+  costs = Array(0..b.length) # i == 0
+  (1..a.length).each do |i|
+    costs[0], nw = i, i - 1  # j == 0; nw is lev(i-1, j)
+    (1..b.length).each do |j|
+      costs[j], nw = [
+        costs[j] + 1, costs[j-1] + 1,
+        a[i-1] == b[j-1] ? nw : nw + 1
+      ].min, costs[j]
+    end
+  end
+  costs[b.length]
+end
+
+def strings_similar_to(target, strings)
+  strings.select do |s|
+    levenshtein_distance(s, target) <= 3 # No specific reasoning for this value
+  end
+end
+
+def port_free?(port)
+  # No idea how well this works, but it's hopefully better than nothing
+
+  log "debug: checking if port #{port} is free"
+  Socket.tcp('127.0.0.1', port, connect_timeout: 0.1) {}
+  false
+rescue Errno::ETIMEDOUT
+  log "debug: port #{port} doesn't seem to be free"
+  false
+rescue Errno::ECONNREFUSED
+  log "debug: port #{port} is free"
+  true
+end
+
+def random_free_port
+  tries = 0
+
+  while tries <= 10
+    port = rand(32768...61000)
+
+    return port if port_free? port
+
+    tries += 1
+  end
+
+  raise "couldn't find open port"
+end
+
+def hosting_providers
+  JUMPBOXES
+    .map { |env, jumpboxes| jumpboxes.keys }
+    .flatten
+    .uniq
+end
+
+def jumpbox_for_environment_and_hosting(environment, hosting)
+  raise 'missing environment' unless environment
+  raise 'missing hosting' unless hosting
+
+  jumpbox = JUMPBOXES[environment][hosting]
+
+  unless jumpbox
+    error "error: couldn't determine jumpbox for #{hosting}/#{environment}"
+    exit 1
+  end
+
+  jumpbox
+end
+
+def single_hosting_provider_for_environment(environment)
+  jumpboxes = JUMPBOXES[environment]
+
+  if jumpboxes.size == 1
+    jumpboxes.keys[0]
+  else
+    false
+  end
+end
+
+def config_file
+  @config_file ||= begin
+    directory = ENV.fetch('XDG_CONFIG_HOME', "#{Dir.home}/.config")
+
+    File.join(directory, 'config.yaml')
+  end
+end
+
+def ssh_username
+  @ssh_username ||= begin
+    if File.exist? config_file
+      config_ssh_username = YAML::load_file(config_file)['ssh_username']
+    end
+
+    config_ssh_username or ENV['USER']
+  end
+end
+
+def user_at_host(user, host)
+  "#{user}@#{host}"
+end
+
+def govuk_node_list_classes(environment, hosting)
+  log "debug: looking up classes in #{hosting}/#{environment}"
+  command = [
+    'ssh',
+    '-o', 'ConnectTimeout=2', # Show a failure quickly
+    user_at_host(
+      ssh_username,
+      jumpbox_for_environment_and_hosting(environment, hosting)
+    ),
+    "govuk_node_list --classes",
+  ].join(' ')
+
+  log "debug: running command: #{command}"
+  output, status = Open3.capture2(command)
+
+  unless status.success?
+    error "\nerror: command failed: #{command}"
+    exit 1
+  end
+
+  classes = output.split("\n").sort
+
+  log "debug: classes:"
+  classes.each { |c| log " - #{c}" }
+
+  classes
+end
+
+def get_domains_for_node_class(target, environment, hosting, ssh_username)
+  command = [
+    'ssh',
+    '-o', 'ConnectTimeout=2', # Show a failure quickly
+    user_at_host(
+      ssh_username,
+      jumpbox_for_environment_and_hosting(environment, hosting)
+    ),
+    "govuk_node_list -c #{target}",
+  ].join(' ')
+
+  output, status = Open3.capture2(command)
+
+  unless status.success?
+    error "error: command failed: #{command}"
+    exit 1
+  end
+
+  output.split("\n").sort
+end
+
+def govuk_directory
+  File.dirname(File.dirname(File.dirname(__FILE__)))
+end
+
+def govuk_developer_docs_applications_data
+  log 'debug: fetching the govuk-developer-docs application data'
+
+  applications_yml_file = File.join(
+    govuk_directory,
+    'govuk-developer-docs',
+    'data',
+    'applications.yml'
+  )
+
+  YAML::load_file(applications_yml_file)
+end
+
+def govuk_puppet_node_class_data(environment, hosting)
+  log "debug: fetching govuk-puppet node class data for #{hosting} #{environment}"
+
+  local_hieradata_root = File.join(
+    govuk_directory,
+    'govuk-puppet',
+    {
+      carrenza: 'hieradata',
+      aws: 'hieradata_aws'
+    }[hosting]
+  )
+
+  hieradata_file = File.join(local_hieradata_root, "#{environment}.yaml")
+  log "debug: reading #{hieradata_file}"
+
+  environment_specific_hieradata = YAML::load_file(hieradata_file)
+
+  if environment_specific_hieradata['node_class']
+    environment_specific_hieradata['node_class']
+  else
+    common_hieradata = YAML::load_file(
+      File.join(local_hieradata_root, 'common.yaml')
+    )
+
+    common_hieradata['node_class']
+  end
+end
+
+def node_classes_for_environment_and_hosting(environment, hosting)
+  govuk_puppet_node_class_data(
+    environment,
+    hosting
+  ).map do |node_class, _data|
+    node_class
+  end
+end
+
+def node_class_for_app(app_name, environment, hosting)
+  log "debug: finding node class for #{app_name} in #{hosting} #{environment}"
+
+  node_class_data = govuk_puppet_node_class_data(
+    environment,
+    hosting
+  )
+
+  app_lookup_hash = {}
+  node_class_data.each do |node_class, data|
+    data['apps'].each do |app|
+      app_lookup_hash[app] = node_class
+    end
+  end
+
+  node_class = app_lookup_hash[app_name]
+
+  log "debug: node class: #{node_class}"
+
+  node_class
+end
+
+def hosting_for_target_and_environment(target, environment)
+  hosting = single_hosting_provider_for_environment(
+    environment
+  )
+
+  unless hosting
+    hosting, name, _number = parse_hosting_name_and_number(target)
+
+    unless hosting
+      hosting = hosting_for_node_type(name, environment)
+    end
+  end
+
+  hosting
+end
+
+def hosting_for_node_type(node_type, environment)
+  log "debug: Looking up hosting for node_type: #{node_type}"
+  hosting = single_hosting_provider_for_environment(environment)
+
+  return hosting if hosting
+
+  aws_node_types = govuk_node_list_classes(environment, :aws)
+  carrenza_node_types = govuk_node_list_classes(environment, :carrenza)
+
+  if (
+    aws_node_types.include?(node_type) &&
+    carrenza_node_types.include?(node_type)
+  )
+    error "error: ambiguous hosting for #{node_type} in #{environment}"
+    newline
+    info "specify the hosting provider and node type, for example: "
+    info "\n  govuk connect ssh aws/#{node_type}\n\n"
+
+    exit 1
+  elsif aws_node_types.include?(node_type)
+    :aws
+  elsif carrenza_node_types.include?(node_type)
+    :carrenza
+  else
+    error "error: couldn't find #{node_type} in #{environment}"
+
+    all_node_types = (aws_node_types + carrenza_node_types).uniq.sort
+    similar_node_types = strings_similar_to(node_type, all_node_types)
+
+    if similar_node_types.any?
+      info "\ndid you mean:"
+      similar_node_types.each { |s| info " - #{s}" }
+    else
+      info "\nall node types:"
+      all_node_types.each { |s| info " - #{s}" }
+    end
+
+    exit 1
+  end
+end
+
+def hosting_for_app(app_name, environment)
+  log "debug: finding hosting for #{app_name} in #{environment}"
+
+  hosting = single_hosting_provider_for_environment(environment)
+
+  if hosting
+    log "debug: this environment has a single hosting provider: #{hosting}"
+    return hosting
+  end
+
+  app_data = govuk_developer_docs_applications_data.find do |data|
+    key = (data.key? 'puppet_name') ? 'puppet_name' : 'github_repo_name'
+
+    data[key] == app_name
+  end
+
+  unless app_data
+    error "error: unknown hosting for #{app_name} in #{environment}"
+    exit 1
+  end
+
+  hosting = app_data['production_hosted_on']
+
+  if hosting == 'aws'
+    log "debug: #{app_name} is hosted in AWS"
+
+    :aws
+  elsif hosting == 'carrenza'
+    log "debug: #{app_name} is hosted in Carrenza"
+
+    :carrenza
+  else
+    error "error: unknown hosting value '#{hosting}' for #{app_name}"
+    exit 1
+  end
+end
+
+def app_console(target, environment)
+  hosting, name, number = parse_hosting_name_and_number(target)
+
+  info "Connecting to the app console for #{bold(name)},\
+ in the #{bold(environment)} environment"
+
+  if hosting
+    info "The selected hosting provider is #{bold(hosting)}"
+  else
+    hosting = hosting_for_app(name, environment)
+
+    info "The relevant hosting provider is #{bold(hosting)}"
+  end
+
+  node_class = node_class_for_app(
+    name,
+    environment,
+    hosting
+  )
+
+  info "The relevant node class is #{bold(node_class)}"
+
+  ssh(
+    {
+      hosting: hosting,
+      name: node_class,
+      number: number
+    },
+    environment,
+    command: "govuk_app_console #{name}"
+  )
+end
+
+def app_dbconsole(target, environment)
+  hosting, name, number = parse_hosting_name_and_number(target)
+
+  unless hosting
+    hosting = hosting_for_app(name, environment)
+  end
+
+  ssh(
+    {
+      hosting: hosting,
+      name: node_class_for_app(
+        name,
+        environment,
+        hosting
+      ),
+      number: number,
+    },
+    environment,
+    command: "govuk_app_dbconsole #{name}"
+  )
+end
+
+def ssh(
+      target,
+      environment,
+      command: false,
+      port_forward: false
+    )
+  log "debug: ssh to #{target} in #{environment}"
+
+  # Split something like aws/backend:2 in to :aws, 'backend', 2
+  hosting, name, number = parse_hosting_name_and_number(target)
+
+  # The hosting might not have been provided, so check if necessary
+  hosting ||= hosting_for_target_and_environment(target, environment)
+
+  if name.end_with?('.internal', '.gov.uk')
+    ssh_target = name
+  else
+    domains = get_domains_for_node_class(
+      name,
+      environment,
+      hosting,
+      ssh_username
+    )
+
+    if domains.length == 1
+      ssh_target = domains.first
+
+      info "There is #{bold('one machine')} to connect to"
+    else
+      n_machines = bold("#{domains.length} machines")
+      info "There are #{n_machines} of this class"
+
+      if number
+        ssh_target = domains[number - 1]
+        info "Connecting to number #{number}"
+      else
+        ssh_target = domains.sample
+        info "Connecting to a random machine (number #{domains.find_index(ssh_target) + 1})"
+      end
+    end
+  end
+
+  ssh_command = [
+    'ssh',
+    '-J', user_at_host(
+      ssh_username,
+      jumpbox_for_environment_and_hosting(environment, hosting)
+    ),
+    user_at_host(
+      ssh_username,
+      ssh_target
+    )
+  ]
+
+  if command
+    ssh_command += [
+      '-t', # Force tty allocation so that interactive commands work
+      command
+    ]
+  elsif port_forward
+    localhost_port = random_free_port
+
+    ssh_command += [
+      '-N',
+      '-L', "#{localhost_port}:127.0.0.1:#{port_forward}"
+    ]
+
+    info "Port forwarding setup, access:\n\n  http://127.0.0.1:#{localhost_port}/\n\n"
+  end
+
+  info "\n#{bold('Running command:')} #{ssh_command.join(' ')}\n\n"
+
+  exec(*ssh_command)
+end
+
+def rabbitmq_root_password_command(hosting, environment)
+  hieradata_directory = {
+    aws: 'puppet_aws',
+    carrenza: 'puppet'
+  }[hosting]
+
+  directory = File.join(
+    govuk_directory,
+    'govuk-secrets',
+    hieradata_directory
+  )
+
+  "cd #{directory} && rake eyaml:decrypt_value[#{environment},govuk_rabbitmq::root_password]"
+end
+
+def hosting_and_environment_from_url(url)
+  uri = URI(url)
+
+  host_to_hosting_and_environment = {
+   'ci-alert.integration.publishing.service.gov.uk' => %i[carrenza ci],
+   'alert.integration.publishing.service.gov.uk' => %i[aws integration],
+   'alert.staging.govuk.digital' => %i[aws staging],
+   'alert.staging.publishing.service.gov.uk' => %i[carrenza staging],
+   'alert.production.govuk.digital' => %i[aws production],
+   'alert.publishing.service.gov.uk' => %i[carrenza production],
+  }
+
+  unless host_to_hosting_and_environment.key? uri.host
+    error "error: unknown hosting and environment for: #{uri.host}"
+    exit 1
+  end
+
+  host_to_hosting_and_environment[uri.host]
+end
+
+def parse_options
+  options = {}
+
+  @option_parser = OptionParser.new do |opts|
+    opts.banner = USAGE_BANNER
+
+    opts.on(
+      '-e',
+      '--environment ENVIRONMENT',
+      'Select which environment to connect to'
+    ) do |o|
+      options[:environment] = o.to_sym
+    end
+    opts.on(
+      '--hosting-and-environment-from-alert-url URL',
+      'Select which environment to connect to based on the alert. URL'
+    ) do |o|
+      hosting, environment = hosting_and_environment_from_url(o)
+      options[:hosting] = hosting
+      options[:environment] = environment
+    end
+    opts.on('-p', '--port-forward SERVICE', 'Connect to a remote port') do |o|
+      options[:port_forward] = o
+    end
+    opts.on('-v', '--verbose', 'Enable more detailed logging') do
+      $verbose = true
+    end
+
+    opts.on('-h', '--help', 'Prints this help') do
+      info opts
+      exit
+    end
+  end
+
+  @option_parser.parse!
+
+  options
+end
+
+def parse_hosting_name_and_number(target)
+  log "debug: parsing target: #{target}"
+  if target.is_a? Hash
+    return %i[hosting name number].map do |key|
+      target[key]
+    end
+  end
+
+  if target.include? '/'
+    hosting, name_and_number = target.split '/'
+
+    hosting = hosting.to_sym
+
+    unless %i[carrenza aws].include? hosting
+      error "error: unknown hosting provider: #{hosting}"
+      newline
+      info "available hosting providers are:"
+      hosting_providers.each { |x| info " - #{x}" }
+
+      exit 1
+    end
+  else
+    name_and_number = target
+  end
+
+  if name_and_number.include? ':'
+    name, number = name_and_number.split ':'
+
+    number = number.to_i
+  else
+    name = name_and_number
+  end
+
+  log "debug: hosting: #{hosting.inspect}, name: #{name.inspect}, number: #{number.inspect}"
+
+  return hosting, name, number
+end
+
+def check_for_target(target)
+  unless target
+    error "error: you must specify the target\n"
+    STDERR.puts USAGE_BANNER
+    STDERR.puts
+    STDERR.puts EXAMPLES
+    exit 1
+  end
+end
+
+TYPES = {
+  'app-console' => Proc.new do |target, environment, _options|
+    check_for_target(target)
+    app_console(target, environment)
+  end,
+
+  'app-dbconsole' => Proc.new do |target, environment, _options|
+    check_for_target(target)
+    app_dbconsole(target, environment)
+  end,
+
+  'rabbitmq' => Proc.new do |target, environment, options|
+    target ||= 'rabbitmq'
+
+    root_password_command = rabbitmq_root_password_command(
+      hosting_for_target_and_environment(target, environment),
+      environment
+    )
+
+    info "You'll need to login as the RabbitMQ #{bold('root')} user."
+    info "Get the password from govuk-secrets, or example:\n\n"
+    info "  #{bold(root_password_command)}"
+    newline
+
+    ssh(
+      target,
+      environment,
+      port_forward: RABBITMQ_PORT,
+    )
+  end,
+
+  'sidekiq-monitoring' => Proc.new do |target, environment, options|
+    ssh(
+      target || 'backend',
+      environment,
+      port_forward: SIDEKIQ_MONITORING_PORT,
+    )
+  end,
+
+  'ssh' => Proc.new do |target, environment, options|
+    check_for_target(target)
+
+    if options.key? :hosting
+      hosting, name, number = parse_hosting_name_and_number(target)
+      if hosting
+        error "error: hosting specified twice"
+        exit 1
+      end
+
+      target = {
+        hosting: options[:hosting],
+        name: name,
+        number: number
+      }
+    end
+
+    ssh(
+      target,
+      environment,
+      port_forward: options[:port_forward]
+    )
+  end
+}
+
+def main
+  system('govuk check-for-govuk-guix-updates')
+
+  options = parse_options
+
+  type, target = ARGV
+
+  unless type
+    error "error: you must specify the connection type\n"
+
+    STDERR.puts @option_parser.help
+
+    STDERR.puts "\nValid connection types are:\n"
+    TYPES.keys.each do |x|
+      STDERR.puts " - #{x}"
+    end
+
+    exit 1
+  end
+
+  handler = TYPES[type]
+
+  unless handler
+    error "error: unknown connection type: #{type}\n"
+
+    STDERR.puts "Valid connection types are:\n"
+    TYPES.keys.each do |x|
+      STDERR.puts " - #{x}"
+    end
+    exit 1
+  end
+
+  environment = options[:environment]&.to_sym
+
+  unless environment
+    error "error: you must specify the environment\n"
+    STDERR.puts @option_parser.help
+    exit 1
+  end
+
+  handler.call(target, environment, options)
+rescue Interrupt
+  # Handle SIGTERM without printing a stacktrace
+  exit 1
+end
+
+main

--- a/govuk-connect
+++ b/govuk-connect
@@ -651,9 +651,12 @@ def ssh(
   # Split something like aws/backend:2 in to :aws, 'backend', 2
   hosting, name, number = parse_hosting_name_and_number(target)
 
-  if name.end_with?('.internal', '.gov.uk')
+  if name.end_with? '.internal'
     ssh_target = name
     hosting = :aws
+  elsif name.end_with? '.gov.uk'
+    ssh_target = name
+    hosting = :carrenza
   else
     # The hosting might not have been provided, so check if necessary
     hosting ||= hosting_for_target_and_environment(target, environment)

--- a/govuk-connect
+++ b/govuk-connect
@@ -506,7 +506,23 @@ def ssh(
       ssh_username
     )
 
-    if domains.length == 1
+    if domains.length.zero?
+      error "error: couldn't find #{name} in #{hosting}/#{environment}"
+
+      node_types = govuk_node_list_classes(environment, hosting)
+
+      similar_node_types = strings_similar_to(name, node_types)
+
+      if similar_node_types.any?
+        info "\ndid you mean:"
+        similar_node_types.each { |s| info " - #{s}" }
+      else
+        info "\nall node types:"
+        node_types.each { |s| info " - #{s}" }
+      end
+
+      exit 1
+    elsif domains.length == 1
       ssh_target = domains.first
 
       info "There is #{bold('one machine')} to connect to"

--- a/govuk-connect
+++ b/govuk-connect
@@ -347,6 +347,8 @@ def node_class_for_app(app_name, environment, hosting)
 
   node_classes = app_lookup_hash[app_name]
 
+  return if node_classes.nil?
+
   if node_classes.length > 1
     error "error: ambiguous node class for #{app_name} in #{environment}"
 

--- a/govuk-connect
+++ b/govuk-connect
@@ -9,18 +9,69 @@
 # Usage: govuk connect TYPE TARGET [options]
 #     -e, --environment ENVIRONMENT    Select which environment to connect to
 #         --hosting-and-environment-from-alert-url URL
-#                                      Select which environment to connect to
-#                                      based on the alert. URL
+#                                      Select which environment to connect to based on the URL provided.
 #     -p, --port-forward SERVICE       Connect to a remote port
 #     -v, --verbose                    Enable more detailed logging
-#     -h, --help                       Prints this help
+#     -h, --help                       Prints usage information and examples
 #
-# Valid connection types are:
-#  - app-console
-#  - app-dbconsole
-#  - rabbitmq
-#  - sidekiq-monitoring
-#  - ssh
+# CONNECTION TYPES
+#   app-console
+#     Launch a console for an application.  For example, a rails console when connecting to a Rails application.
+#   app-dbconsole
+#     Launch a console for the database for an application.
+#   rabbitmq
+#     Setup port forwarding to the RabbitMQ admin interface.
+#   sidekiq-monitoring
+#     Setup port forwarding to the Sidekiq Monitoring application.
+#   ssh
+#     Connect to a machine through SSH.
+#
+# MACHINE TARGET
+#   The ssh, rabbitmq and sidekiq-monitoring connection types target
+#   machines.
+#
+#   The machine can be specified by name, for example:
+#
+#     gouvk connect ssh -e integration backend
+#
+#   If the hosting provider is ambiguous, you'll need to specify it prior
+#   to the name, for example:
+#
+#     govuk connect ssh -e staging aws/backend
+#
+#   If you want to connect to a specific machine, you can specify a number
+#   after the name, for example:
+#
+#     govuk connect ssh -e integration backend:2
+#
+# APPLICATION TARGET
+#   The app-console and app-dbconsole connection types target
+#   applications.
+#
+#   The application is specified by name, for example:
+#
+#     govuk connect app-console -e integration publishing-api
+#
+#   If the node class is ambiguous, you'll need to specify it prior to
+#   the name, for example:
+#
+#     govuk connect app-console -e integration whitehall_backend/whitehall
+#
+#   If you want to connect to a specific machine, you can specify a
+#   number after the name, for example:
+#
+#     govuk connect app-console -e integration publishing-api:2
+#
+# EXAMPLES
+#   govuk connect ssh --environment integration backend
+#
+#   govuk connect app-console --environment staging publishing-api
+#
+#   govuk connect app-dbconsole -e integration whitehall_backend/whitehall
+#
+#   gouvk connect rabbitmq -e staging aws/rabbitmq
+#
+#   govuk connect sidekiq-monitoring -e integration
 
 
 require 'uri'
@@ -30,22 +81,69 @@ require 'socket'
 require 'timeout'
 require 'optparse'
 
+def bold(string)
+  "\e[1m#{string}\e[0m"
+end
+
 USAGE_BANNER = 'Usage: govuk connect TYPE TARGET [options]'
 
-EXAMPLES = <<~EXAMPLES
-  For example:
+EXAMPLES = <<EXAMPLES
+  govuk connect ssh --environment integration backend
 
-    govuk connect ssh --environment integration backend
+  govuk connect app-console --environment staging publishing-api
 
-    govuk connect app-console --environment staging publishing-api
+  govuk connect app-dbconsole -e integration whitehall_backend/whitehall
 
-    govuk connect app-dbconsole -e integration whitehall_backend/whitehall
+  gouvk connect rabbitmq -e staging aws/rabbitmq
 
-    gouvk connect rabbitmq -e staging aws/rabbitmq
-
-    govuk connect sidekiq-monitoring -e integration
-
+  govuk connect sidekiq-monitoring -e integration
 EXAMPLES
+
+MACHINE_TARGET_DESCRIPTION  = <<DOCS
+  The ssh, rabbitmq and sidekiq-monitoring connection types target
+  machines.
+
+  The machine can be specified by name, for example:
+
+    gouvk connect ssh -e integration #{bold('backend')}
+
+  If the hosting provider is ambiguous, you'll need to specify it prior
+  to the name, for example:
+
+    govuk connect ssh -e staging #{bold('aws/')}backend
+
+  If you want to connect to a specific machine, you can specify a number
+  after the name, for example:
+
+    govuk connect ssh -e integration backend#{bold(':2')}
+DOCS
+
+APP_TARGET_DESCRIPTION = <<DOCS
+  The app-console and app-dbconsole connection types target
+  applications.
+
+  The application is specified by name, for example:
+
+    govuk connect app-console -e integration #{bold('publishing-api')}
+
+  If the node class is ambiguous, you'll need to specify it prior to
+  the name, for example:
+
+    govuk connect app-console -e integration #{bold('whitehall_backend/')}whitehall
+
+  If you want to connect to a specific machine, you can specify a
+  number after the name, for example:
+
+    govuk connect app-console -e integration publishing-api#{bold(':2')}
+DOCS
+
+CONNECTION_TYPE_DESCRIPTIONS = {
+  'ssh' => 'Connect to a machine through SSH.',
+  'app-console' => 'Launch a console for an application.  For example, a rails console when connecting to a Rails application.',
+  'app-dbconsole' => 'Launch a console for the database for an application.',
+  'rabbitmq' => 'Setup port forwarding to the RabbitMQ admin interface.',
+  'sidekiq-monitoring' => 'Setup port forwarding to the Sidekiq Monitoring application.'
+}
 
 RABBITMQ_PORT = 15672
 SIDEKIQ_MONITORING_PORT = 3211
@@ -69,10 +167,6 @@ JUMPBOXES = {
 
 def log(message)
   STDERR.puts message if $verbose
-end
-
-def bold(string)
-  "\e[1m#{string}\e[0m"
 end
 
 def newline
@@ -686,7 +780,7 @@ def parse_options
     end
     opts.on(
       '--hosting-and-environment-from-alert-url URL',
-      'Select which environment to connect to based on the alert. URL'
+      'Select which environment to connect to based on the URL provided.'
     ) do |o|
       hosting, environment = hosting_and_environment_from_url(o)
       options[:hosting] = hosting
@@ -699,8 +793,24 @@ def parse_options
       $verbose = true
     end
 
-    opts.on('-h', '--help', 'Prints this help') do
+    opts.on('-h', '--help', 'Prints usage information and examples') do
       info opts
+      newline
+      info bold('CONNECTION TYPES')
+      TYPES.keys.each do |x|
+        info "  #{x}"
+        description = CONNECTION_TYPE_DESCRIPTIONS[x]
+        info "    #{description}" if description
+      end
+      newline
+      info bold('MACHINE TARGET')
+      info MACHINE_TARGET_DESCRIPTION
+      newline
+      info bold('APPLICATION TARGET')
+      info APP_TARGET_DESCRIPTION
+      newline
+      info bold('EXAMPLES')
+      info EXAMPLES
       exit
     end
   end

--- a/govuk-connect
+++ b/govuk-connect
@@ -6,7 +6,7 @@
 # different hosting providers.
 #
 #
-# Usage: govuk connect TYPE TARGET [options]
+# Usage: govuk-connect TYPE TARGET [options]
 #     -e, --environment ENVIRONMENT    Select which environment to connect to
 #         --hosting-and-environment-from-alert-url URL
 #                                      Select which environment to connect to based on the URL provided.
@@ -32,17 +32,17 @@
 #
 #   The machine can be specified by name, for example:
 #
-#     govuk connect ssh -e integration backend
+#     govuk-connect ssh -e integration backend
 #
 #   If the hosting provider is ambiguous, you'll need to specify it prior
 #   to the name, for example:
 #
-#     govuk connect ssh -e staging aws/backend
+#     govuk-connect ssh -e staging aws/backend
 #
 #   If you want to connect to a specific machine, you can specify a number
 #   after the name, for example:
 #
-#     govuk connect ssh -e integration backend:2
+#     govuk-connect ssh -e integration backend:2
 #
 # APPLICATION TARGET
 #   The app-console and app-dbconsole connection types target
@@ -50,28 +50,28 @@
 #
 #   The application is specified by name, for example:
 #
-#     govuk connect app-console -e integration publishing-api
+#     govuk-connect app-console -e integration publishing-api
 #
 #   If the node class is ambiguous, you'll need to specify it prior to
 #   the name, for example:
 #
-#     govuk connect app-console -e integration whitehall_backend/whitehall
+#     govuk-connect app-console -e integration whitehall_backend/whitehall
 #
 #   If you want to connect to a specific machine, you can specify a
 #   number after the name, for example:
 #
-#     govuk connect app-console -e integration publishing-api:2
+#     govuk-connect app-console -e integration publishing-api:2
 #
 # EXAMPLES
-#   govuk connect ssh --environment integration backend
+#   govuk-connect ssh --environment integration backend
 #
-#   govuk connect app-console --environment staging publishing-api
+#   govuk-connect app-console --environment staging publishing-api
 #
-#   govuk connect app-dbconsole -e integration whitehall_backend/whitehall
+#   govuk-connect app-dbconsole -e integration whitehall_backend/whitehall
 #
-#   govuk connect rabbitmq -e staging aws/rabbitmq
+#   govuk-connect rabbitmq -e staging aws/rabbitmq
 #
-#   govuk connect sidekiq-monitoring -e integration
+#   govuk-connect sidekiq-monitoring -e integration
 
 
 require 'uri'
@@ -85,18 +85,18 @@ def bold(string)
   "\e[1m#{string}\e[0m"
 end
 
-USAGE_BANNER = 'Usage: govuk connect TYPE TARGET [options]'
+USAGE_BANNER = 'Usage: govuk-connect TYPE TARGET [options]'
 
 EXAMPLES = <<EXAMPLES
-  govuk connect ssh --environment integration backend
+  govuk-connect ssh --environment integration backend
 
-  govuk connect app-console --environment staging publishing-api
+  govuk-connect app-console --environment staging publishing-api
 
-  govuk connect app-dbconsole -e integration whitehall_backend/whitehall
+  govuk-connect app-dbconsole -e integration whitehall_backend/whitehall
 
-  govuk connect rabbitmq -e staging aws/rabbitmq
+  govuk-connect rabbitmq -e staging aws/rabbitmq
 
-  govuk connect sidekiq-monitoring -e integration
+  govuk-connect sidekiq-monitoring -e integration
 EXAMPLES
 
 MACHINE_TARGET_DESCRIPTION  = <<DOCS
@@ -105,17 +105,17 @@ MACHINE_TARGET_DESCRIPTION  = <<DOCS
 
   The machine can be specified by name, for example:
 
-    govuk connect ssh -e integration #{bold('backend')}
+    govuk-connect ssh -e integration #{bold('backend')}
 
   If the hosting provider is ambiguous, you'll need to specify it prior
   to the name, for example:
 
-    govuk connect ssh -e staging #{bold('aws/')}backend
+    govuk-connect ssh -e staging #{bold('aws/')}backend
 
   If you want to connect to a specific machine, you can specify a number
   after the name, for example:
 
-    govuk connect ssh -e integration backend#{bold(':2')}
+    govuk-connect ssh -e integration backend#{bold(':2')}
 DOCS
 
 APP_TARGET_DESCRIPTION = <<DOCS
@@ -124,17 +124,17 @@ APP_TARGET_DESCRIPTION = <<DOCS
 
   The application is specified by name, for example:
 
-    govuk connect app-console -e integration #{bold('publishing-api')}
+    govuk-connect app-console -e integration #{bold('publishing-api')}
 
   If the node class is ambiguous, you'll need to specify it prior to
   the name, for example:
 
-    govuk connect app-console -e integration #{bold('whitehall_backend/')}whitehall
+    govuk-connect app-console -e integration #{bold('whitehall_backend/')}whitehall
 
   If you want to connect to a specific machine, you can specify a
   number after the name, for example:
 
-    govuk connect app-console -e integration publishing-api#{bold(':2')}
+    govuk-connect app-console -e integration publishing-api#{bold(':2')}
 DOCS
 
 CONNECTION_TYPE_DESCRIPTIONS = {
@@ -461,7 +461,7 @@ def node_class_for_app(app_name, environment, hosting)
     newline
     info "specify the node class and application mame, for example: "
     node_classes.each do |node_class|
-      info "\n  govuk connect app-console -e #{environment} #{node_class}/#{app_name}"
+      info "\n  govuk-connect app-console -e #{environment} #{node_class}/#{app_name}"
     end
     newline
 
@@ -508,7 +508,7 @@ def hosting_for_node_type(node_type, environment)
     newline
     info "specify the hosting provider and node type, for example: "
     hosting_providers.each do |hosting_provider|
-      info "\n  govuk connect ssh #{bold(hosting_provider)}/#{node_type}"
+      info "\n  govuk-connect ssh #{bold(hosting_provider)}/#{node_type}"
     end
     info "\n"
 

--- a/govuk-connect
+++ b/govuk-connect
@@ -32,7 +32,7 @@
 #
 #   The machine can be specified by name, for example:
 #
-#     gouvk connect ssh -e integration backend
+#     govuk connect ssh -e integration backend
 #
 #   If the hosting provider is ambiguous, you'll need to specify it prior
 #   to the name, for example:
@@ -69,7 +69,7 @@
 #
 #   govuk connect app-dbconsole -e integration whitehall_backend/whitehall
 #
-#   gouvk connect rabbitmq -e staging aws/rabbitmq
+#   govuk connect rabbitmq -e staging aws/rabbitmq
 #
 #   govuk connect sidekiq-monitoring -e integration
 
@@ -94,7 +94,7 @@ EXAMPLES = <<EXAMPLES
 
   govuk connect app-dbconsole -e integration whitehall_backend/whitehall
 
-  gouvk connect rabbitmq -e staging aws/rabbitmq
+  govuk connect rabbitmq -e staging aws/rabbitmq
 
   govuk connect sidekiq-monitoring -e integration
 EXAMPLES
@@ -105,7 +105,7 @@ MACHINE_TARGET_DESCRIPTION  = <<DOCS
 
   The machine can be specified by name, for example:
 
-    gouvk connect ssh -e integration #{bold('backend')}
+    govuk connect ssh -e integration #{bold('backend')}
 
   If the hosting provider is ambiguous, you'll need to specify it prior
   to the name, for example:

--- a/govuk-connect
+++ b/govuk-connect
@@ -977,6 +977,9 @@ def main
 
   double_dash_index = ARGV.index '--'
   if double_dash_index
+    # This is used in the case of passing extra options to ssh, the --
+    # acts as a separator, so to avoid optparse interpreting those
+    # options, split ARGV around -- before parsing the options
     rest = ARGV[double_dash_index + 1, ARGV.length]
     argv = ARGV[0, double_dash_index]
 

--- a/govuk-connect
+++ b/govuk-connect
@@ -359,6 +359,12 @@ def node_class_for_app(app_name, environment, hosting)
 
   if node_classes.length > 1
     error "error: ambiguous node class for #{app_name} in #{environment}"
+    newline
+    info "specify the node class and application mame, for example: "
+    node_classes.each do |node_class|
+      info "\n  govuk connect app-console -e #{environment} #{node_class}/#{app_name}"
+    end
+    newline
 
     exit 1
   else

--- a/govuk-connect
+++ b/govuk-connect
@@ -3,7 +3,7 @@
 #
 # This script aims to make it easy to connect to various parts of the GOV.UK
 # infrastructure. It aims to provide a consistent way to do this, even across
-# different mosting providers.
+# different hosting providers.
 #
 #
 # Usage: govuk connect TYPE TARGET [options]

--- a/govuk-connect
+++ b/govuk-connect
@@ -651,12 +651,13 @@ def ssh(
   # Split something like aws/backend:2 in to :aws, 'backend', 2
   hosting, name, number = parse_hosting_name_and_number(target)
 
-  # The hosting might not have been provided, so check if necessary
-  hosting ||= hosting_for_target_and_environment(target, environment)
-
   if name.end_with?('.internal', '.gov.uk')
     ssh_target = name
+    hosting = :aws
   else
+    # The hosting might not have been provided, so check if necessary
+    hosting ||= hosting_for_target_and_environment(target, environment)
+
     domains = get_domains_for_node_class(
       name,
       environment,

--- a/govuk-connect
+++ b/govuk-connect
@@ -56,6 +56,14 @@ def error(message)
   STDERR.puts "\e[1m\e[31m#{message}\e[0m"
 end
 
+def print_ssh_username_configuration_help
+  info "The SSH username used was: #{bold(ssh_username)}"
+  info "Check this is correct, and it it isn't run the following command to set the correct username"
+  newline
+  info "  #{bold('govuk config ssh_username USERNAME')}"
+  newline
+end
+
 # From Rosetta Code: https://rosettacode.org/wiki/Levenshtein_distance#Ruby
 def levenshtein_distance(a, b)
   a, b = a.downcase, b.downcase
@@ -176,6 +184,8 @@ def govuk_node_list_classes(environment, hosting)
 
   unless status.success?
     error "\nerror: command failed: #{command}"
+    newline
+    print_ssh_username_configuration_help
     exit 1
   end
 
@@ -202,6 +212,8 @@ def get_domains_for_node_class(target, environment, hosting, ssh_username)
 
   unless status.success?
     error "error: command failed: #{command}"
+    newline
+    print_ssh_username_configuration_help
     exit 1
   end
 

--- a/govuk-connect
+++ b/govuk-connect
@@ -1,5 +1,28 @@
 #!/usr/bin/env ruby
 
+#
+# This script aims to make it easy to connect to various parts of the GOV.UK
+# infrastructure. It aims to provide a consistent way to do this, even across
+# different mosting providers.
+#
+#
+# Usage: govuk connect TYPE TARGET [options]
+#     -e, --environment ENVIRONMENT    Select which environment to connect to
+#         --hosting-and-environment-from-alert-url URL
+#                                      Select which environment to connect to
+#                                      based on the alert. URL
+#     -p, --port-forward SERVICE       Connect to a remote port
+#     -v, --verbose                    Enable more detailed logging
+#     -h, --help                       Prints this help
+#
+# Valid connection types are:
+#  - app-console
+#  - app-dbconsole
+#  - rabbitmq
+#  - sidekiq-monitoring
+#  - ssh
+
+
 require 'uri'
 require 'yaml'
 require 'open3'

--- a/govuk-connect
+++ b/govuk-connect
@@ -620,8 +620,10 @@ def hosting_and_environment_from_url(url)
    'ci-alert.integration.publishing.service.gov.uk' => %i[carrenza ci],
    'alert.integration.publishing.service.gov.uk' => %i[aws integration],
    'alert.staging.govuk.digital' => %i[aws staging],
+   'alert.blue.staging.govuk.digital' => %i[aws staging],
    'alert.staging.publishing.service.gov.uk' => %i[carrenza staging],
    'alert.production.govuk.digital' => %i[aws production],
+   'alert.blue.production.govuk.digital' => %i[aws production],
    'alert.publishing.service.gov.uk' => %i[carrenza production],
   }
 

--- a/govuk-connect
+++ b/govuk-connect
@@ -760,6 +760,14 @@ def main
     exit 1
   end
 
+  unless JUMPBOXES.key? environment
+    error "error: unknown environment '#{environment}'"
+    newline
+    info "Valid environments are:"
+    JUMPBOXES.keys.each { |e| info " - #{e}" }
+    exit 1
+  end
+
   handler.call(target, environment, options)
 rescue Interrupt
   # Handle SIGTERM without printing a stacktrace

--- a/govuk-connect
+++ b/govuk-connect
@@ -981,7 +981,6 @@ TYPES = {
 }
 
 def main
-  system('govuk check-for-govuk-guix-updates')
   check_ruby_version_greater_than(required_major: 2, required_minor: 0)
 
   double_dash_index = ARGV.index '--'

--- a/govuk-connect
+++ b/govuk-connect
@@ -35,7 +35,15 @@ USAGE_BANNER = 'Usage: govuk connect TYPE TARGET [options]'
 EXAMPLES = <<~EXAMPLES
   For example:
 
+    govuk connect ssh --environment integration backend
+
     govuk connect app-console --environment staging publishing-api
+
+    govuk connect app-dbconsole -e integration whitehall_backend/whitehall
+
+    gouvk connect rabbitmq -e staging aws/rabbitmq
+
+    govuk connect sidekiq-monitoring -e integration
 
 EXAMPLES
 

--- a/govuk-connect
+++ b/govuk-connect
@@ -691,18 +691,29 @@ def check_for_target(target)
   end
 end
 
+def check_for_additional_arguments(command, args)
+  unless args.empty?
+    error "error: #{command} doesn't support arguments: #{args}"
+    exit 1
+  end
+end
+
 TYPES = {
-  'app-console' => Proc.new do |target, environment, _options|
+  'app-console' => Proc.new do |target, environment, args, _options|
     check_for_target(target)
+    check_for_additional_arguments('app-console', args)
     govuk_app_command(target, environment, 'console')
   end,
 
-  'app-dbconsole' => Proc.new do |target, environment, _options|
+  'app-dbconsole' => Proc.new do |target, environment, args, _options|
     check_for_target(target)
+    check_for_additional_arguments('app-dbconsole', args)
     govuk_app_command(target, environment, 'dbconsole')
   end,
 
-  'rabbitmq' => Proc.new do |target, environment, options|
+  'rabbitmq' => Proc.new do |target, environment, args, options|
+    check_for_additional_arguments('rabbitmq', args)
+
     target ||= 'rabbitmq'
 
     root_password_command = rabbitmq_root_password_command(
@@ -722,7 +733,8 @@ TYPES = {
     )
   end,
 
-  'sidekiq-monitoring' => Proc.new do |target, environment, options|
+  'sidekiq-monitoring' => Proc.new do |target, environment, args, options|
+    check_for_additional_arguments('sidekiq-monitoring', args)
     ssh(
       target || 'backend',
       environment,
@@ -730,7 +742,7 @@ TYPES = {
     )
   end,
 
-  'ssh' => Proc.new do |target, environment, options|
+  'ssh' => Proc.new do |target, environment, args, options|
     check_for_target(target)
 
     if options.key? :hosting
@@ -760,7 +772,7 @@ def main
 
   options = parse_options
 
-  type, target = ARGV
+  type, target, *rest = ARGV
 
   unless type
     error "error: you must specify the connection type\n"
@@ -803,7 +815,7 @@ def main
     exit 1
   end
 
-  handler.call(target, environment, options)
+  handler.call(target, environment, rest, options)
 rescue Interrupt
   # Handle SIGTERM without printing a stacktrace
   exit 1

--- a/govuk-connect
+++ b/govuk-connect
@@ -274,6 +274,19 @@ def node_classes_for_environment_and_hosting(environment, hosting)
   end
 end
 
+def application_names_from_node_class_data(environment, hosting)
+  node_class_data = govuk_puppet_node_class_data(
+    environment,
+    hosting
+  )
+
+  all_names = node_class_data.flat_map do |node_class, data|
+    data['apps']
+  end
+
+  all_names.sort.uniq
+end
+
 def node_class_for_app(app_name, environment, hosting)
   log "debug: finding node class for #{app_name} in #{hosting} #{environment}"
 
@@ -390,10 +403,10 @@ def hosting_for_app(app_name, environment)
   end
 end
 
-def app_console(target, environment)
+def govuk_app_command(target, environment, command)
   hosting, name, number = parse_hosting_name_and_number(target)
 
-  info "Connecting to the app console for #{bold(name)},\
+  info "Connecting to the app #{command} for #{bold(name)},\
  in the #{bold(environment)} environment"
 
   if hosting
@@ -410,6 +423,29 @@ def app_console(target, environment)
     hosting
   )
 
+  unless node_class
+    error "error: application '#{name}' not found."
+    newline
+
+    application_names = application_names_from_node_class_data(
+      environment,
+      hosting
+    )
+
+    similar_application_names = strings_similar_to(name, application_names)
+    if similar_application_names.any?
+      info "did you mean:"
+      similar_application_names.each { |s| info " - #{s}" }
+    else
+      info "all applications:"
+      newline
+      info "  #{application_names.join(', ')}"
+      newline
+    end
+
+    exit 1
+  end
+
   info "The relevant node class is #{bold(node_class)}"
 
   ssh(
@@ -419,29 +455,7 @@ def app_console(target, environment)
       number: number
     },
     environment,
-    command: "govuk_app_console #{name}"
-  )
-end
-
-def app_dbconsole(target, environment)
-  hosting, name, number = parse_hosting_name_and_number(target)
-
-  unless hosting
-    hosting = hosting_for_app(name, environment)
-  end
-
-  ssh(
-    {
-      hosting: hosting,
-      name: node_class_for_app(
-        name,
-        environment,
-        hosting
-      ),
-      number: number,
-    },
-    environment,
-    command: "govuk_app_dbconsole #{name}"
+    command: "govuk_app_#{command} #{name}"
   )
 end
 
@@ -645,12 +659,12 @@ end
 TYPES = {
   'app-console' => Proc.new do |target, environment, _options|
     check_for_target(target)
-    app_console(target, environment)
+    govuk_app_command(target, environment, 'console')
   end,
 
   'app-dbconsole' => Proc.new do |target, environment, _options|
     check_for_target(target)
-    app_dbconsole(target, environment)
+    govuk_app_command(target, environment, 'dbconsole')
   end,
 
   'rabbitmq' => Proc.new do |target, environment, options|

--- a/govuk-connect
+++ b/govuk-connect
@@ -486,7 +486,8 @@ def ssh(
       target,
       environment,
       command: false,
-      port_forward: false
+      port_forward: false,
+      additional_arguments: []
     )
   log "debug: ssh to #{target} in #{environment}"
 
@@ -579,6 +580,8 @@ def ssh(
 
     info "Port forwarding setup, access:\n\n  http://127.0.0.1:#{localhost_port}/\n\n"
   end
+
+  ssh_command += additional_arguments
 
   info "\n#{bold('Running command:')} #{ssh_command.join(' ')}\n\n"
 
@@ -778,7 +781,8 @@ TYPES = {
     ssh(
       target,
       environment,
-      port_forward: options[:port_forward]
+      port_forward: options[:port_forward],
+      additional_arguments: args
     )
   end
 }
@@ -786,9 +790,22 @@ TYPES = {
 def main
   system('govuk check-for-govuk-guix-updates')
 
-  options = parse_options
+  double_dash_index = ARGV.index '--'
+  if double_dash_index
+    rest = ARGV[double_dash_index + 1, ARGV.length]
+    argv = ARGV[0, double_dash_index]
 
-  type, target, *rest = ARGV
+    ARGV.clear
+    ARGV.concat argv
+
+    options = parse_options
+
+    type, target = ARGV
+  else
+    options = parse_options
+
+    type, target, *rest = ARGV
+  end
 
   unless type
     error "error: you must specify the connection type\n"

--- a/govuk-connect
+++ b/govuk-connect
@@ -492,6 +492,18 @@ def ssh(
       info "There are #{n_machines} of this class"
 
       if number
+        unless number > 0
+          newline
+          error "error: invalid machine number '#{number}', it must be > 0"
+          exit 1
+        end
+
+        unless number <= domains.length
+          newline
+          error "error: cannot connect to machine number: #{number}"
+          exit 1
+        end
+
         ssh_target = domains[number - 1]
         info "Connecting to number #{number}"
       else

--- a/govuk-connect
+++ b/govuk-connect
@@ -392,7 +392,10 @@ def hosting_for_node_type(node_type, environment)
     error "error: ambiguous hosting for #{node_type} in #{environment}"
     newline
     info "specify the hosting provider and node type, for example: "
-    info "\n  govuk connect ssh aws/#{node_type}\n\n"
+    hosting_providers.each do |hosting_provider|
+      info "\n  govuk connect ssh #{bold(hosting_provider)}/#{node_type}"
+    end
+    info "\n"
 
     exit 1
   elsif aws_node_types.include?(node_type)


### PR DESCRIPTION
The `govuk-connect` script started in the `govuk-guix` Git repository as that included other interconnected scripts. It's not actually related to Guix though, so this Pull Request looks at moving it to this Git repository.

I've copied over the Git history, as I didn't want to loose that.

This follows on from the previous (failed) attempt at moving some more non-Guix related stuff out of `govuk-guix`: https://github.com/alphagov/govuk-guix/issues/36