### PR TITLE
Add support for gem package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0
+
+* Initial release with previous work from `govuk-guix`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# GOV.UK Connect
+
+This is a command line tool to help you connect to GOV.UK's infrastructure.
+
+## Installation
+
+To install:
+
+```bash
+gem install govuk_connect
+```

--- a/bin/govuk-connect
+++ b/bin/govuk-connect
@@ -3,6 +3,6 @@
 lib = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require 'govuk-connect'
+require 'govuk_connect'
 
 main

--- a/bin/govuk-connect
+++ b/bin/govuk-connect
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+lib = File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'govuk-connect'
+
+main

--- a/govuk-connect.gemspec
+++ b/govuk-connect.gemspec
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'govuk_connect/version'
+
+Gem::Specification.new do |s|
+  s.name = 'govuk-connect'
+  s.version = GovukConnect::VERSION
+  s.required_ruby_version = '>= 2.3.0'
+
+  s.summary = 'govuk-connect command line tool'
+  s.description = 'Command line tool to connect to GOV.UK infrastructure'
+
+  s.authors = ['Government Digital Service']
+  s.email = ['govuk-dev@digital.cabinet-office.gov.uk']
+  s.files = Dir['{lib,bin}/**/*']
+  s.executables = ['govuk-connect']
+
+  s.homepage = 'https://github.com/alphagov/govuk-connect'
+  s.license = 'MIT'
+end

--- a/lib/govuk-connect.rb
+++ b/lib/govuk-connect.rb
@@ -1053,5 +1053,3 @@ rescue Interrupt
   # Handle SIGTERM without printing a stacktrace
   exit 1
 end
-
-main

--- a/lib/govuk_connect.rb
+++ b/lib/govuk_connect.rb
@@ -80,6 +80,7 @@ require 'open3'
 require 'socket'
 require 'timeout'
 require 'optparse'
+require 'govuk_connect/version'
 
 def bold(string)
   "\e[1m#{string}\e[0m"
@@ -816,6 +817,10 @@ def parse_options
       newline
       info bold('EXAMPLES')
       info EXAMPLES
+      exit
+    end
+    opts.on('-V', '--version', 'Prints version information') do
+      info "#{GovukConnect::VERSION}"
       exit
     end
   end

--- a/lib/govuk_connect/version.rb
+++ b/lib/govuk_connect/version.rb
@@ -1,0 +1,3 @@
+module GovukConnect
+  VERSION = "0.0.1".freeze
+end


### PR DESCRIPTION
This allows the tool to be packaged and distributed as a Ruby gem - discussed in #2. This PR includes:
- Gemspec file
- Reorganising code into `lib` and `bin` directories`
- Adding explicit versioning into the source code following SemVers conventions