### PR TITLE
Fix path to govuk directory

### DIFF
--- a/lib/govuk_connect.rb
+++ b/lib/govuk_connect.rb
@@ -378,7 +378,7 @@ def get_domains_for_node_class(target, environment, hosting, ssh_username)
 end
 
 def govuk_directory
-  File.dirname(File.dirname(File.dirname(__FILE__)))
+  File.join(ENV['HOME'], 'govuk')
 end
 
 def govuk_puppet_node_class_data(environment, hosting)


### PR DESCRIPTION
This fixes an issue where the wrong path is generated to the govuk directory. Previously generated the path relative to the govuk-connect repository. However, this is different when govuk-connect is installed as a gem. This causes certain commands such as app-console to fail.