### PR TITLE
Bump version to 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.0.2
 
 * Fix path to path to govuk directory
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
-# 0.1.0
+# Unreleased
+
+* Fix path to path to govuk directory
+
+# 0.0.1
 
 * Initial release with previous work from `govuk-guix`

--- a/lib/govuk_connect/version.rb
+++ b/lib/govuk_connect/version.rb
@@ -1,3 +1,3 @@
 module GovukConnect
-  VERSION = "0.0.1".freeze
+  VERSION = "0.0.2".freeze
 end


### PR DESCRIPTION
Bumping version to release the fix the govuk path which prevent some commands from working.