### PR TITLE
README: Add a few more words and some installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ govuk-connect ssh -e integration frontend
 
 ## Installation
 
-To install:
+### With Homebrew on macOS or Linux:
+
+```bash
+brew tap alphagov/gds # This will exist if you use the gds-cli
+brew install govuk-connect
+```
+
+### With RubyGems:
 
 ```bash
 sudo gem install govuk-connect
@@ -18,6 +25,13 @@ sudo gem install govuk-connect
 
 ## Usage
 
-```bash
-govuk-connect --help
+If you have the gds-cli installed (you [should do](https://docs.publishing.service.gov.uk/manual/access-aws-console.html)!), you can use this tool within it. This means you only have to use one tool to do AWS and SSH.
+
 ```
+gds govuk connect --help
+```
+
+It can be shortened to `gds govuk c`.
+
+Whichever installation method you choose, you can use the above method or the standalone `govuk-connect` binary.
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ brew install govuk-connect
 > it to work:
 > 
 > ```
-> gem uninstall govuk-connect
+> sudo gem uninstall govuk-connect
 > rbenv rehash
 > ```
 
@@ -43,4 +43,3 @@ gds govuk connect --help
 It can be shortened to `gds govuk c`.
 
 Whichever installation method you choose, you can use the above method or the standalone `govuk-connect` binary.
-

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ brew tap alphagov/gds # This will exist if you use the gds-cli
 brew install govuk-connect
 ```
 
+> Note: If you previously installed `govuk-connect` via RubyGems, but
+> switched to using Homebrew, you may have to do the following to get
+> it to work:
+> 
+> ```
+> gem uninstall govuk-connect
+> rbenv rehash
+> ```
+
 ### With RubyGems:
 
 ```bash


### PR DESCRIPTION
- Installation instructions that don't involve `sudo` are always good.
  Now there's a Homebrew formula, so people can install our two tools
  with the same package manager.
- This still needs docs about building for local changes, and releasing,
  but I'm hoping to automate the latter fairly soon.