### PR TITLE
Tweak the triggers for the build

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,4 +1,8 @@
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
Previously we triggered a build on all 'push' events. This changes
the trigger to 'pull_request', which offers a couple of advantages:

- It will (still) trigger on any pushes to the PR branch ('synchronize')
- It means the build will run for PRs raised by external contributors

This also adds a special trigger for the 'master' branch, so that the
build runs after merging a PR, which may include (future) release steps.