### PR TITLE
Downgrade min Ruby to 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,10 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 2.5
+
+# This is necessary because the min version (2.3)
+# falls outside the target versions supported
+# by RuboCop. We should remove this when the min
+# version becomes compatible with RuboCop again.
+Gemspec/RequiredRubyVersion:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1
+
+* Downgrade minimum Ruby version to 2.3 ([#22](https://github.com/alphagov/govuk-connect/pull/22))
+
 # 0.1.0
 
 * Restructure code to support testing ([#10](https://github.com/alphagov/govuk-connect/pull/10), [#16](https://github.com/alphagov/govuk-connect/pull/16))

--- a/govuk-connect.gemspec
+++ b/govuk-connect.gemspec
@@ -7,7 +7,7 @@ require "govuk_connect/version"
 Gem::Specification.new do |s|
   s.name = "govuk-connect"
   s.version = GovukConnect::VERSION
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 2.3"
 
   s.summary = "govuk-connect command line tool"
   s.description = "Command line tool to connect to GOV.UK infrastructure"

--- a/lib/govuk_connect/version.rb
+++ b/lib/govuk_connect/version.rb
@@ -1,3 +1,3 @@
 module GovukConnect
-  VERSION = "0.1.0".freeze
+  VERSION = "0.1.1".freeze
 end


### PR DESCRIPTION
https://trello.com/c/erHV3TCc/166-add-tests-for-govuk-connect

Previously we increased the minimum Ruby version to 2.4, and then 2.5,
noting that most people have 2.6 installed. However, when installing
via Homebrew, this causes an error since the formula calls out to system
Ruby, which for many is still 2.3 (OS Mojave).

This downgrades the minimum Ruby version back to 2.3, so that Homebrew
installations continue to work.