### PR TITLE
ci: Run on `push` and `pull_request` events

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,8 +1,4 @@
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
- As per the [decision](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-123-github-actions-ci.md#findings-from-some-initial-explorations-into-using-github-actions) in the ratified RFC 123.
