### PR TITLE
cli: Replatforming need to be able to SSH into the test environment

### DIFF
--- a/lib/govuk_connect/cli.rb
+++ b/lib/govuk_connect/cli.rb
@@ -79,6 +79,9 @@ class GovukConnect::CLI
   SIDEKIQ_MONITORING_PORT = 3211
 
   JUMPBOXES = {
+    test: {
+      aws: "jumpbox.pink.test.govuk.digital",
+    },
     ci: {
       carrenza: "ci-jumpbox.integration.publishing.service.gov.uk",
     },


### PR DESCRIPTION
- Replatforming are using the `govuk-infrastructure-test` AWS account as a test bed for spikes into what the new platform could look like. But first we have to spin up an existing platform.
- Prior to this change, trying to SSH into our new jumpbox (`test` env, `pink` stack) meant we saw this error:

```
➜ gds govuk connect ssh -e test jumpbox
error: unknown environment 'test'

Valid environments are:
 - ci
 - integration
 - staging
 - production
```
