### PR TITLE
Implement scp-push and scp-pull commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add `scp-push` and `scp-pull` command to copy files between machines ([#41](https://github.com/alphagov/govuk-connect/pull/41))
+
 # 0.2.1
 
 * Fix parsing of `--` arguments for SSH ([#39](https://github.com/alphagov/govuk-connect/pull/39))

--- a/lib/govuk_connect/cli.rb
+++ b/lib/govuk_connect/cli.rb
@@ -872,20 +872,23 @@ class GovukConnect::CLI
 
   def types
     @types ||= {
-      "app-console" => proc do |target, environment, args, _options|
+      "app-console" => proc do |target, environment, args, extra_args, _options|
         check_for_target(target)
         check_for_additional_arguments("app-console", args)
+        check_for_additional_arguments("app-console", extra_args)
         govuk_app_command(target, environment, "console")
       end,
 
-      "app-dbconsole" => proc do |target, environment, args, _options|
+      "app-dbconsole" => proc do |target, environment, args, extra_args, _options|
         check_for_target(target)
         check_for_additional_arguments("app-dbconsole", args)
+        check_for_additional_arguments("app-dbconsole", extra_args)
         govuk_app_command(target, environment, "dbconsole")
       end,
 
-      "rabbitmq" => proc do |target, environment, args, _options|
+      "rabbitmq" => proc do |target, environment, args, extra_args, _options|
         check_for_additional_arguments("rabbitmq", args)
+        check_for_additional_arguments("rabbitmq", extra_args)
 
         target ||= "rabbitmq"
 
@@ -906,8 +909,9 @@ class GovukConnect::CLI
         )
       end,
 
-      "sidekiq-monitoring" => proc do |target, environment, args, _options|
+      "sidekiq-monitoring" => proc do |target, environment, args, extra_args, _options|
         check_for_additional_arguments("sidekiq-monitoring", args)
+        check_for_additional_arguments("sidekiq-monitoring", extra_args)
         ssh(
           target || "backend",
           environment,
@@ -915,7 +919,7 @@ class GovukConnect::CLI
         )
       end,
 
-      "ssh" => proc do |target, environment, args, options|
+      "ssh" => proc do |target, environment, args, extra_args, options|
         check_for_target(target)
         target = target_from_options(target, options)
 
@@ -923,7 +927,7 @@ class GovukConnect::CLI
           target,
           environment,
           port_forward: options[:port_forward],
-          additional_arguments: args,
+          additional_arguments: [args, extra_args].flatten,
         )
       end,
     }
@@ -932,22 +936,20 @@ class GovukConnect::CLI
   def main(argv)
     check_ruby_version_greater_than(required_major: 2, required_minor: 0)
 
+    extra_arguments_after_double_dash = []
+
     double_dash_index = argv.index "--"
     if double_dash_index
-      # This is used in the case of passing extra options to ssh, the --
-      # acts as a separator, so to avoid optparse interpreting those
-      # options, split argv around -- before parsing the options
-      rest = argv[double_dash_index + 1, argv.length]
+      # This is used in the case of passing extra options to ssh and
+      # scp, the -- acts as a separator, so to avoid optparse
+      # interpreting those as options, split argv around -- before
+      # parsing the options
+      extra_arguments_after_double_dash = argv[double_dash_index + 1, argv.length]
       argv = argv[0, double_dash_index]
-
-      options = parse_options(argv)
-
-      type, target = argv
-    else
-      options = parse_options(argv)
-
-      type, target, *rest = argv
     end
+
+    govuk_connect_options = parse_options(argv)
+    type, target, *extra_arguments_before_double_dash = argv
 
     unless type
       error "error: you must specify the connection type\n"
@@ -981,7 +983,7 @@ class GovukConnect::CLI
       exit 1
     end
 
-    environment = options[:environment]&.to_sym
+    environment = govuk_connect_options[:environment]&.to_sym
 
     unless environment
       error "error: you must specify the environment\n"
@@ -997,7 +999,13 @@ class GovukConnect::CLI
       exit 1
     end
 
-    handler.call(target, environment, rest, options)
+    handler.call(
+      target,
+      environment,
+      extra_arguments_before_double_dash,
+      extra_arguments_after_double_dash,
+      govuk_connect_options,
+    )
   rescue Interrupt
     # Handle SIGTERM without printing a stacktrace
     exit 1

--- a/spec/integration/scp_spec.rspec
+++ b/spec/integration/scp_spec.rspec
@@ -1,0 +1,65 @@
+RSpec.describe "scp" do
+  include SCPHelper
+
+  let(:cli) { GovukConnect::CLI.new }
+
+  before { disable_any_exec(cli) }
+
+  it "supports SCPing to a numbered machine" do
+    stub_govuk_node_list(
+      machine_class: "jumpbox",
+      hostnames: %w[foo1 foo2],
+      environment: :integration,
+    )
+
+    args = scp_push_command(
+      environment: :integration,
+      hostname: "foo2",
+      sources: %w[file1 file2],
+      destination: "file3",
+    )
+
+    allow(cli).to receive(:exec).with(*args)
+    cli.main(["-e", "integration", "scp-push", "jumpbox:2", "file1", "file2", "file3"])
+    expect(cli).to have_received(:exec)
+  end
+
+  it "supports SCPing from a numbered machine" do
+    stub_govuk_node_list(
+      machine_class: "jumpbox",
+      hostnames: %w[foo1 foo2],
+      environment: :integration,
+    )
+
+    args = scp_pull_command(
+      environment: :integration,
+      hostname: "foo2",
+      sources: %w[file1 file2],
+      destination: "file3",
+    )
+
+    allow(cli).to receive(:exec).with(*args)
+    cli.main(["-e", "integration", "scp-pull", "jumpbox:2", "file1", "file2", "file3"])
+    expect(cli).to have_received(:exec)
+  end
+
+  it "supports passing extra arguments with --" do
+    stub_govuk_node_list(
+      machine_class: "jumpbox",
+      hostnames: %w[foo1 foo2],
+      environment: :integration,
+    )
+
+    args = scp_pull_command(
+      environment: :integration,
+      hostname: "foo2",
+      sources: %w[file1 file2],
+      destination: "file3",
+      additional_arguments: %w[-o SomeSCPOption=foo],
+    )
+
+    allow(cli).to receive(:exec).with(*args)
+    cli.main(["-e", "integration", "scp-pull", "jumpbox:2", "file1", "file2", "file3", "--", "-o", "SomeSCPOption=foo"])
+    expect(cli).to have_received(:exec)
+  end
+end

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -90,4 +90,16 @@ RSpec.describe "ssh" do
     cli.main(["-e", "integration", "ssh", "hostname.internal", "--", "ls", "--", "/"])
     expect(cli).to have_received(:exec)
   end
+
+  it "supports mixing -- and non--- extra arguments" do
+    args = ssh_command(
+      environment: :integration,
+      hostname: "hostname.internal",
+      suffix: ["ls", "/"],
+    )
+
+    allow(cli).to receive(:exec).with(*args)
+    cli.main(["-e", "integration", "ssh", "hostname.internal", "ls", "--", "/"])
+    expect(cli).to have_received(:exec)
+  end
 end

--- a/spec/support/scp_helper.rb
+++ b/spec/support/scp_helper.rb
@@ -1,0 +1,41 @@
+module SCPHelper
+  def scp_push_command(environment:,
+                       hostname:,
+                       sources:,
+                       destination:,
+                       provider: :aws,
+                       additional_arguments: [])
+    jumpbox = GovukConnect::CLI::JUMPBOXES.dig(environment, provider)
+    [
+      "scp",
+      "-o",
+      "ProxyJump=test@#{jumpbox}",
+      "-o",
+      "User=test",
+      *additional_arguments,
+      "--",
+      *sources,
+      "#{hostname}:#{destination}",
+    ]
+  end
+
+  def scp_pull_command(environment:,
+                       hostname:,
+                       sources:,
+                       destination:,
+                       provider: :aws,
+                       additional_arguments: [])
+    jumpbox = GovukConnect::CLI::JUMPBOXES.dig(environment, provider)
+    [
+      "scp",
+      "-o",
+      "ProxyJump=test@#{jumpbox}",
+      "-o",
+      "User=test",
+      *additional_arguments,
+      "--",
+      *sources.map { |source| "#{hostname}:#{source}" },
+      destination,
+    ]
+  end
+end


### PR DESCRIPTION
Each take a list of paths (at least two in length), where the last
paths is the destination and the others are the sources.  scp-push
copies the sources from the current machine to the destination path on
the target machine; scp-pull does the opposite, downloading paths from
the target machine to the path on the local machine.

---

[Trello card](https://trello.com/c/QcGSCmcL/130-support-scp-with-govuk-connect)