### PR TITLE
stop sorting aws nodes

### DIFF
--- a/lib/govuk_connect/cli.rb
+++ b/lib/govuk_connect/cli.rb
@@ -316,7 +316,11 @@ class GovukConnect::CLI
       exit 1
     end
 
-    output.split("\n").sort
+    if hosting == :aws
+      output.split("\n")
+    else
+      output.split("\n").sort
+    end
   end
 
   def govuk_directory


### PR DESCRIPTION
This is done now in govuk_node_list in AWS by PR: https://github.com/alphagov/govuk-puppet/pull/10644