### PR TITLE
Improve the help text

### DIFF
--- a/lib/govuk_connect/cli.rb
+++ b/lib/govuk_connect/cli.rb
@@ -15,22 +15,22 @@ class GovukConnect::CLI
     self.class.bold(string)
   end
 
-  USAGE_BANNER = "Usage: govuk-connect TYPE TARGET [options]".freeze
+  USAGE_BANNER = "Usage: gds govuk connect TYPE TARGET [options]".freeze
 
   EXAMPLES = <<-EXAMPLES.freeze
-    govuk-connect ssh --environment integration backend
+    gds govuk connect ssh --environment integration backend
 
-    govuk-connect scp-push --environment integration backend filename.txt /tmp/
+    gds govuk connect scp-push --environment integration backend filename.txt /tmp/
 
-    govuk-connect scp-pull --environment integration backend /tmp/filename.txt ~/Downloads/
+    gds govuk connect scp-pull --environment integration backend /tmp/filename.txt ~/Downloads/
 
-    govuk-connect app-console --environment staging publishing-api
+    gds govuk connect app-console --environment staging publishing-api
 
-    govuk-connect app-dbconsole -e integration whitehall_backend/whitehall
+    gds govuk connect app-dbconsole -e integration whitehall_backend/whitehall
 
-    govuk-connect rabbitmq -e staging aws/rabbitmq
+    gds govuk connect rabbitmq -e staging aws/rabbitmq
 
-    govuk-connect sidekiq-monitoring -e integration
+    gds govuk connect sidekiq-monitoring -e integration
   EXAMPLES
 
   MACHINE_TARGET_DESCRIPTION = <<-DOCS.freeze
@@ -39,17 +39,17 @@ class GovukConnect::CLI
 
     The machine can be specified by name, for example:
 
-      govuk-connect ssh -e integration #{bold('backend')}
+      gds govuk connect ssh -e integration #{bold('backend')}
 
     If the hosting provider is ambiguous, you'll need to specify it prior
     to the name, for example:
 
-      govuk-connect ssh -e staging #{bold('aws/')}backend
+      gds govuk connect ssh -e staging #{bold('aws/')}backend
 
     If you want to connect to a specific machine, you can specify a number
     after the name, for example:
 
-      govuk-connect ssh -e integration backend#{bold(':2')}
+      gds govuk connect ssh -e integration backend#{bold(':2')}
   DOCS
 
   APP_TARGET_DESCRIPTION = <<-DOCS.freeze
@@ -58,17 +58,17 @@ class GovukConnect::CLI
 
     The application is specified by name, for example:
 
-      govuk-connect app-console -e integration #{bold('publishing-api')}
+      gds govuk connect app-console -e integration #{bold('publishing-api')}
 
     If the node class is ambiguous, you'll need to specify it prior to
     the name, for example:
 
-      govuk-connect app-console -e integration #{bold('whitehall_backend/')}whitehall
+      gds govuk connect app-console -e integration #{bold('whitehall_backend/')}whitehall
 
     If you want to connect to a specific machine, you can specify a
     number after the name, for example:
 
-      govuk-connect app-console -e integration publishing-api#{bold(':2')}
+      gds govuk connect app-console -e integration publishing-api#{bold(':2')}
   DOCS
 
   CONNECTION_TYPE_DESCRIPTIONS = {
@@ -405,7 +405,7 @@ class GovukConnect::CLI
       print_empty_line
       info "specify the node class and application mame, for example: "
       node_classes.each do |node_class|
-        info "\n  govuk-connect app-console -e #{environment} #{node_class}/#{app_name}"
+        info "\n  gds govuk connect app-console -e #{environment} #{node_class}/#{app_name}"
       end
       print_empty_line
 
@@ -449,7 +449,7 @@ class GovukConnect::CLI
       print_empty_line
       info "specify the hosting provider and node type, for example: "
       hosting_providers.each do |hosting_provider|
-        info "\n  govuk-connect ssh #{bold(hosting_provider)}/#{node_type}"
+        info "\n  gds govuk connect ssh #{bold(hosting_provider)}/#{node_type}"
       end
       info "\n"
 

--- a/lib/govuk_connect/cli.rb
+++ b/lib/govuk_connect/cli.rb
@@ -715,8 +715,11 @@ class GovukConnect::CLI
         @verbose = true
       end
 
-      opts.on("-h", "--help", "Prints usage information and examples") do
+      opts.on("-h", "--help", "Prints usage examples and information") do
         info opts
+        print_empty_line
+        info bold("EXAMPLES")
+        info EXAMPLES
         print_empty_line
         info bold("CONNECTION TYPES")
         types.keys.each do |x|
@@ -730,9 +733,6 @@ class GovukConnect::CLI
         print_empty_line
         info bold("APPLICATION TARGET")
         info APP_TARGET_DESCRIPTION
-        print_empty_line
-        info bold("EXAMPLES")
-        info EXAMPLES
         exit
       end
       opts.on("-V", "--version", "Prints version information") do


### PR DESCRIPTION
- Move usage examples to the top of the `--help` output.
  - This was discussed in the dev tools meeting as a thing that would make usage of this tool better: easier discoverability of the usage examples (answering common questions like "how do I SSH").

- Convert `govuk-connect` in examples to `gds govuk connect`
  - Yes, this is more typing, but it was reported in the summer 2020 dev tools survey that people found the help text confusing because it didn't match what they were used to running in their terminals.
  - It was a conscious, deliberate choice to include `govuk-connect` from `gds-cli` because the difference in tools was confusing to people. The number of times there were questions like "if I want to SSH, what tool do I use?". Now people just have to think "GDS CLI" for everything from AWS through SSH to the VPN (and can access that help output to see what they're missing).
  - While one day it might be a fun project to convert this from Ruby to Go and embed it directly into the GDS CLI, rather than having to shell out, no-one's done that yet. And GOV.UK Replatforming have [plans](https://github.com/alphagov/govuk-replatforming-discovery-2020/blob/main/proposals/003-ecs-fargate-consoles.md) (private repo) for 2021 when the infrastructure will be different, anyway.
  - I can see why this change might be controversial, but I think it's a helpful one. If people still use `govuk-connect` as a standalone gem, then they know that they do and that's cool. But the vast majority of developers don't. And we're trying to make the majority of devs' lives easier - GOV.UK is complicated enough!

Fixes #44.