### PR TITLE
Remove staging carrenza from govuk-connect

### DIFF
--- a/lib/govuk_connect/cli.rb
+++ b/lib/govuk_connect/cli.rb
@@ -93,7 +93,6 @@ class GovukConnect::CLI
       aws: "jumpbox.integration.publishing.service.gov.uk",
     },
     staging: {
-      carrenza: "jumpbox.staging.publishing.service.gov.uk",
       aws: "jumpbox.staging.govuk.digital",
     },
     production: {


### PR DESCRIPTION
The jumpbox in carrenza staging is no longer reachable, so there's no
need for it to be in govuk-connect anymore.

The situation at the moment is a little confusing, as if you don't
specify a hosting provider (e.g. `gds govuk connect -e staging
mirrorer`),
it will attempt to get the list of nodes from carrenza
first. This doesn't work, because there's no jumpbox, instead it errors
in a way that doesn't clearly prompt the user to use the `aws/` prefix.

(The jumpbox is still there in production, along with a few other
machines, so that one can stay for now)