### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0
+
+* Remove carrenza staging ([#51](https://github.com/alphagov/govuk-connect/pull/51))
+
 # 0.3.3
 
 * Improve the `--help` text to match what users run on a day-to-day basis ([#49](https://github.com/alphagov/govuk-connect/pull/49))

--- a/lib/govuk_connect/version.rb
+++ b/lib/govuk_connect/version.rb
@@ -1,3 +1,3 @@
 module GovukConnect
-  VERSION = "0.3.3".freeze
+  VERSION = "0.4.0".freeze
 end


### PR DESCRIPTION
This version removes carrenza from staging, which makes sshing into
things in staging a little simpler (as you no longer need the `aws/`
prefix).