### PR TITLE
Add concourse pipeline

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -15,6 +15,8 @@ jobs:
         source:
           repository: ruby
           tag: 2.6
+          username: ((docker_hub_username))
+          password: ((docker_hub_authtoken))
         type: registry-image
       inputs:
       - name: govuk-connect

--- a/concourse.yml
+++ b/concourse.yml
@@ -1,0 +1,40 @@
+jobs:
+- name: update-pipeline
+  plan:
+    - get: govuk-connect
+      trigger: true
+    - set_pipeline: govuk-connect
+      file: govuk-connect/concourse.yml
+- name: release-gem
+  plan:
+  - get: govuk-connect
+    trigger: true
+  - config:
+      container_limits: {}
+      image_resource:
+        source:
+          repository: ruby
+          tag: 2.6
+        type: registry-image
+      inputs:
+      - name: govuk-connect
+      outputs:
+      - name: gems
+        path: dist
+      platform: linux
+      run:
+        args:
+        - -c
+        - |
+          echo "=== Building Gem..."
+          cd govuk-connect
+          mkdir dist
+          gem build govuk-connect.gemspec --output dist/release.gem
+        path: /bin/bash
+    task: build-gem
+resources:
+- icon: github-circle
+  name: govuk-connect
+  source:
+    uri: https://github.com/alphagov/govuk-connect
+  type: git


### PR DESCRIPTION
This concourse pipeline is already running in Concourse
https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/govuk-connect

This adds the update-pipeline job, and puts the config for this pipeline into a git repo.

After this is merged we'll need to update the pipeline manually before the `set_pipeline` step takes over that job:

```
fly sp -t cd-govuk-tools -c concourse.yml -p govuk-connect
```