### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.5.0
+
 * Remove support for sidekiq-monitoring ([#54](https://github.com/alphagov/govuk-connect/pull/54))
 * Remove carrenza CI and production ([#55](https://github.com/alphagov/govuk-connect/pull/55))
 

--- a/lib/govuk_connect/version.rb
+++ b/lib/govuk_connect/version.rb
@@ -1,3 +1,3 @@
 module GovukConnect
-  VERSION = "0.4.0".freeze
+  VERSION = "0.5.0".freeze
 end


### PR DESCRIPTION
This includes changes made since September: https://github.com/alphagov/govuk-connect/compare/0.4.0..master