### PR TITLE
Automate pushing gem to RubyGems

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,25 @@ Whichever installation method you choose, you can use the above method or the st
 
 ## Releases
 
-When you've merged the PR that bumps the version (change value in `lib/govuk_connect/version.rb`), 
-publish a release tag and the gem to RubyGems from the `master` branch:
+### 1. Release the gem
+
+When you've merged the PR that bumps the version (change value in `lib/govuk_connect/version.rb`),
+publish a release tag and the gem to RubyGems from the `master` branch.
+
+The `gem push` step is done automatically by the [Concourse pipeline][], when you
+update the `version.rb` file.
 
 ```bash
+# Note: You shouldn't need to do this manually. This is done by Concourse.
 gem build govuk-connect
 gem push govuk-connect-<version>.gem # Credentials are in govuk-secrets/pass under packages/rubygems
 git tag <version> # eg 0.0.3
 git push origin <version>
 ```
+
+[Concourse pipeline]: https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/govuk-connect
+
+### 2. Update Homebrew
 
 To raise a PR to bump the Homebrew formula version, run:
 
@@ -67,4 +77,3 @@ To raise a PR to bump the Homebrew formula version, run:
 > bump-formula-pr` again. If you really can't do it, [consider
 > reopening a previous PR on this
 > topic](https://github.com/alphagov/govuk-connect/pull/21).
-

--- a/concourse.yml
+++ b/concourse.yml
@@ -1,3 +1,24 @@
+---
+resource_types:
+  - name: rubygems
+    type: docker-image
+    source:
+      repository: govuk/concourse-rubygems
+      tag: 0.0.3
+
+resources:
+- icon: github-circle
+  name: govuk-connect
+  source:
+    uri: https://github.com/alphagov/govuk-connect
+  type: git
+- name: rubygems
+  type: rubygems
+  source:
+    gem_name: govuk-connect
+    credentials: |
+      :rubygems_api_key: ((rubygems_api_key))
+
 jobs:
 - name: update-pipeline
   plan:
@@ -9,7 +30,8 @@ jobs:
   plan:
   - get: govuk-connect
     trigger: true
-  - config:
+  - task: build-gem
+    config:
       container_limits: {}
       image_resource:
         source:
@@ -33,10 +55,9 @@ jobs:
           mkdir dist
           gem build govuk-connect.gemspec --output dist/release.gem
         path: /bin/bash
-    task: build-gem
-resources:
-- icon: github-circle
-  name: govuk-connect
-  source:
-    uri: https://github.com/alphagov/govuk-connect
-  type: git
+  - put: rubygems
+    params:
+      gem_dir: dist
+      gem_regex: govuk-connect
+    get_params:
+      skip_download: true


### PR DESCRIPTION
The Concourse pipeline currently just builds the gem and discards it. This enables Concourse to also release the gem. The push step is not idempotent - it will fail the job if the same version is pushed twice ([fix is in review](troykinsella/concourse-rubygems-resource#2)).

We'll still need to manually make a change to add new versions to brew, I've modified the docs to hopefully make that clearer:
https://github.com/alphagov/homebrew-gds/blob/master/Formula/govuk-connect.rb#L4
