### PR TITLE
Allow port forwarding to a remote host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.5.1
+
+* Add support for port forwarding to a remote host ([#56](https://github.com/alphagov/govuk-connect/pull/59))
+
 # 0.5.0
 
 * Remove support for sidekiq-monitoring ([#54](https://github.com/alphagov/govuk-connect/pull/54))

--- a/lib/govuk_connect/cli.rb
+++ b/lib/govuk_connect/cli.rb
@@ -543,10 +543,15 @@ class GovukConnect::CLI
     elsif port_forward
       localhost_port = random_free_port
 
+      host = "127.0.0.1"
+      if port_forward.is_a?(String) && port_forward.include?(":")
+        host, port_forward = port_forward.split(":")
+      end
+
       ssh_command += [
         "-N",
         "-L",
-        "#{localhost_port}:127.0.0.1:#{port_forward}",
+        "#{localhost_port}:#{host}:#{port_forward}",
       ]
 
       info "Port forwarding setup, access:\n\n  http://127.0.0.1:#{localhost_port}/\n\n"
@@ -650,7 +655,7 @@ class GovukConnect::CLI
         options[:hosting] = hosting
         options[:environment] = environment
       end
-      opts.on("-p", "--port-forward SERVICE", "Connect to a remote port") do |o|
+      opts.on("-p", "--port-forward [host:]hostport", "Connect to a remote host and port (remote host defaults to 127.0.0.1)") do |o|
         options[:port_forward] = o
       end
       opts.on("-v", "--verbose", "Enable more detailed logging") do

--- a/lib/govuk_connect/version.rb
+++ b/lib/govuk_connect/version.rb
@@ -1,3 +1,3 @@
 module GovukConnect
-  VERSION = "0.5.0".freeze
+  VERSION = "0.5.1".freeze
 end

--- a/spec/integration/ssh_spec.rb
+++ b/spec/integration/ssh_spec.rb
@@ -31,6 +31,30 @@ RSpec.describe "ssh" do
     expect(cli).to have_received(:exec)
   end
 
+  it "supports forwarding to a port" do
+    args = ssh_command(
+      environment: :integration,
+      hostname: "hostname.internal",
+      suffix: ["-N", "-L", /\d+:127[.]0[.]0[.]1:80/],
+    )
+
+    allow(cli).to receive(:exec).with(*args)
+    cli.main(["-e", "integration", "ssh", "hostname.internal", "--port-forward", "80"])
+    expect(cli).to have_received(:exec)
+  end
+
+  it "supports forwarding to a port and a host" do
+    args = ssh_command(
+      environment: :integration,
+      hostname: "hostname.internal",
+      suffix: ["-N", "-L", /\d+:elasticsearch:80/],
+    )
+
+    allow(cli).to receive(:exec).with(*args)
+    cli.main(["-e", "integration", "ssh", "hostname.internal", "--port-forward", "elasticsearch:80"])
+    expect(cli).to have_received(:exec)
+  end
+
   it "supports SSHing to a specific provider" do
     stub_govuk_node_list(
       machine_class: "jumpbox",


### PR DESCRIPTION
We've got some awful docs for port forwarding to elasticsearch here:

https://docs.publishing.service.gov.uk/manual/alerts/elasticsearch-cluster-health.html#use-the-elasticsearch-api

govuk-connect already has the ability to port forward to a port on
loopback on the remote machine. This adds the ability to forward to a
remote host, so you can do things like:

```
gds govuk connect ssh -e staging search -p elasticsearch6:80
```

(Note: you can emit most of the FQDN because there's clever setup in
/etc/resolv.conf on the remote hosts)

(P.S. I hate doing this, because we're just gradually wrapping the
entire ssh CLI. Other suggestions welcome.)