### PR TITLE
Fix dbconsole undefined local variable or method `name_and_number'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.5.1
+
+* Fix dbconsole undefined local variable or method `name_and_number' ([#61](https://github.com/alphagov/govuk-connect/pull/61))
+
 # 0.5.0
 
 * Remove support for sidekiq-monitoring ([#54](https://github.com/alphagov/govuk-connect/pull/54))

--- a/lib/govuk_connect/cli.rb
+++ b/lib/govuk_connect/cli.rb
@@ -741,7 +741,7 @@ class GovukConnect::CLI
     end
 
     if app_name_and_number.include? ":"
-      app_name, number = name_and_number.split ":"
+      app_name, number = app_name_and_number.split ":"
 
       number = number.to_i
     else

--- a/lib/govuk_connect/version.rb
+++ b/lib/govuk_connect/version.rb
@@ -1,3 +1,3 @@
 module GovukConnect
-  VERSION = "0.5.0".freeze
+  VERSION = "0.5.1".freeze
 end

--- a/spec/integration/app_console_spec.rb
+++ b/spec/integration/app_console_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "app-(db)console" do
     )
 
     allow(cli).to receive(:exec).with(*args)
-    cli.main(["-e", "integration", "app-dbconsole", "my-app"])
+    cli.main(["-e", "integration", "app-dbconsole", "my-app:1"])
     expect(cli).to have_received(:exec)
   end
 


### PR DESCRIPTION
You might want to open a dbconsole on a specific numbered instance. For
example, so you can run a query and save the results to a file which you can
then SCP off the server.

At the moment there's a typo in the variable name, so it errors. Come back
static typing, all is forgiven.