### PR TITLE
Fix incorrect call to ssh_capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.5.2
+
+* Fix incorrect call to ssh_capture ([#62](https://github.com/alphagov/govuk-connect/pull/62))
+
 # 0.5.1
 
 * Fix dbconsole undefined local variable or method `name_and_number' ([#61](https://github.com/alphagov/govuk-connect/pull/61))

--- a/lib/govuk_connect/cli.rb
+++ b/lib/govuk_connect/cli.rb
@@ -254,7 +254,7 @@ class GovukConnect::CLI
 
   def govuk_node_list_classes(environment, hosting)
     log "debug: looking up classes in #{hosting}/#{environment}"
-    classes = ssh_capture("govuk_node_list --classes").sort
+    classes = ssh_capture(environment, hosting, "govuk_node_list --classes").sort
 
     log "debug: classes:"
     classes.each { |c| log " - #{c}" }

--- a/lib/govuk_connect/version.rb
+++ b/lib/govuk_connect/version.rb
@@ -1,3 +1,3 @@
 module GovukConnect
-  VERSION = "0.5.1".freeze
+  VERSION = "0.5.2".freeze
 end


### PR DESCRIPTION
This method has three arguments, not one.

I spotted this when I got this error:

```
bin/govuk-connect ssh -e integration licencefinder
error: couldn't find licencefinder in aws/integration
Traceback (most recent call last):
        7: from bin/govuk-connect:8:in `<main>'
        6: from /Users/richardtowers/govuk/govuk-connect/lib/govuk_connect.rb:5:in `main'
        5: from /Users/richardtowers/govuk/govuk-connect/lib/govuk_connect/cli.rb:1011:in `main'
        4: from /Users/richardtowers/govuk/govuk-connect/lib/govuk_connect/cli.rb:900:in `block in types'
        3: from /Users/richardtowers/govuk/govuk-connect/lib/govuk_connect/cli.rb:522:in `ssh'
        2: from /Users/richardtowers/govuk/govuk-connect/lib/govuk_connect/cli.rb:794:in `ssh_target'
        1: from /Users/richardtowers/govuk/govuk-connect/lib/govuk_connect/cli.rb:257:in `govuk_node_list_classes'
/Users/richardtowers/govuk/govuk-connect/lib/govuk_connect/cli.rb:274:in `ssh_capture': wrong number of arguments (given 1, expected 3) (ArgumentError)
```

I should have got this error instead:

```
bin/govuk-connect ssh -e integration licencefinder
error: couldn't find licencefinder in aws/integration

all node types:
 - account
 - apt
 - asset_master
 - ... etc ...
```

... because `govuk-connect ssh` takes a node class, not an app name.

This shows a gap in test coverage, but I don't have the energy to fix that just now.