### PR TITLE
Switch master branch references to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     needs: test
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Whichever installation method you choose, you can use the above method or the st
 ### 1. Release the gem
 
 When you've merged the PR that bumps the version (change value in `lib/govuk_connect/version.rb`),
-publish a release tag and the gem to RubyGems from the `master` branch.
+publish a release tag and the gem to RubyGems from the `main` branch.
 
 The `gem push` step is done automatically by the GitHub Action, when you
 update the `version.rb` file.


### PR DESCRIPTION
The default branch has been renamed in GitHub from master to main