### PR TITLE
Create a test_matrix GitHub Action job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       matrix:
         # Should go down to lowest non-EOL version
         # https://www.ruby-lang.org/en/downloads/branches/
-        ruby: [2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, '3.0']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 on: [push, pull_request]
 
 jobs:
-  test:
+  test_matrix:
     strategy:
       matrix:
         # Should go down to lowest non-EOL version
@@ -15,6 +15,12 @@ jobs:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
       - run: bundle exec rake
+
+  test:
+    needs: test_matrix
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All matrix tests have passed 🚀"
 
   release:
     needs: test


### PR DESCRIPTION
This changes the configuration of the jobs to work around a problem with
the automated status checks. On GOV.UK repos we require that a status
check of "test" is met by a repo, however in matrix builds that are
named "test" there is no singular "test" check, instead there are
multiple "test (<distinguishing criteria>)" jobs and thus the status
check is never satisfied.

By having an individual test job that requires all the matrix jobs to
pass we can work around this issue. As per: https://github.community/t/status-check-for-a-matrix-jobs/127354/3