### PR TITLE
Provide compatibility with Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       matrix:
         # Should go down to lowest non-EOL version
         # https://www.ruby-lang.org/en/downloads/branches/
-        ruby: [2.6, 2.7, '3.0']
+        ruby: [2.6, 2.7, '3.0', 3.1]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix YAML alias parsing error for Ruby 3.1 ([#69](https://github.com/alphagov/govuk-connect/pull/69))
 * Drop support for Ruby 2.5
 
 # 0.5.2

--- a/spec/integration/app_console_spec.rb
+++ b/spec/integration/app_console_spec.rb
@@ -60,12 +60,12 @@ RSpec.describe "app-(db)console" do
     base_path = "/home/user/govuk/govuk-puppet/hieradata_aws"
     file_path = "#{base_path}/#{environment}.yaml"
 
-    allow(YAML).to receive(:load_file).with(file_path)
+    allow(cli).to receive(:load_yaml).with(file_path)
       .and_return("node_class" => node_classes)
   end
 
   def disable_yaml_load_file
-    allow(YAML).to receive(:load_file) do |*args|
+    allow(cli).to receive(:load_yaml) do |*args|
       raise "Unexpected call to YAML: #{args}"
     end
   end


### PR DESCRIPTION
Ruby 3.1 contains Psych version 4 as the default YAML parsing library.
This has a backwards compatibility break where YAML.load_file behaviour
has changed from an unsafe load to a safe load [1]. This causes an exception
to occur when using GOV.UK Puppet Hieradata YAML files are parsed, as
these make use of aliases - which is a feature that needs to be
enabled for YAML in safe load.

To resolve this issue I've set a conditional to check if the safe_load
method exists on the YAML object. I did consider whether it could be
resoled by pinning the psych dependency, but this seemed a bit delicate
as this tool has been authored to have no external dependencies and is
installed explicitly without them [2].

I couldn't identify an approach to apply a test for this that was
consistent with this repo's code and test conventions. Due to the
fluctuating standard library it'd have been a little contrived.

Before:

```
➜  ~ govuk-connect app-console -e integration asset-manager
Connecting to the app console for asset-manager,   in the integration environment
The relevant hosting provider is aws
/usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:430:in `visit_Psych_Nodes_Alias': Unknown alias: node_class (Psych::BadAlias)
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:345:in `block in revive_hash'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `each'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `each_slice'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `revive_hash'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:167:in `visit_Psych_Nodes_Mapping'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:345:in `block in revive_hash'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `each'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `each_slice'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `revive_hash'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:167:in `visit_Psych_Nodes_Mapping'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:318:in `visit_Psych_Nodes_Document'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych.rb:335:in `safe_load'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych.rb:370:in `load'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych.rb:671:in `block in load_file'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych.rb:670:in `open'
	from /usr/local/Cellar/ruby/3.1.0/lib/ruby/3.1.0/psych.rb:670:in `load_file'
```

After:

```
➜  ~ govuk-connect app-console -e integration asset-manager
Connecting to the app console for asset-manager,   in the integration environment
The relevant hosting provider is aws
The relevant node class is backend
```

[1]: https://github.com/ruby/psych/pull/487
[2]: https://github.com/alphagov/homebrew-gds/blob/de1fb95fbda6219ad7158ab0c71253dcb55822d9/Formula/govuk-connect.rb#L12