### PR TITLE
Bump to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.6.0
 
 * Fix YAML alias parsing error for Ruby 3.1 ([#69](https://github.com/alphagov/govuk-connect/pull/69))
 * Drop support for Ruby 2.5

--- a/lib/govuk_connect/version.rb
+++ b/lib/govuk_connect/version.rb
@@ -1,3 +1,3 @@
 module GovukConnect
-  VERSION = "0.5.2".freeze
+  VERSION = "0.6.0".freeze
 end


### PR DESCRIPTION
I'm marking this as a minor release since support for a Ruby version is
being dropped (2.5)