### PR TITLE
Use shared workflow to publish gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,31 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "All matrix tests have passed 🚀"
-
-  release:
+     
+  publish:
     needs: test
-    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
-      contents: write 
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-
-      # Update to >= v3.0.5
-      # https://gitlab.com/gitlab-org/gitlab-qa/-/issues/431
-    - run: gem update --system
-
-    - env:
-        GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}
-      run: |
-        VERSION=$(ruby -e "puts eval(File.read('govuk-connect.gemspec')).version")
-        GEM_VERSION=$(gem list --exact --remote govuk-connect)
-        if [ "${GEM_VERSION}" != "govuk-connect (${VERSION})" ]; then
-          gem build govuk-connect.gemspec
-          gem push "govuk-connect-${VERSION}.gem"
-        fi
-        if ! git ls-remote --tags --exit-code origin v${VERSION}; then
-          git tag v${VERSION}
-          git push --tags
-        fi
+      contents: write
+    uses: alphagov/govuk-infrastructure/.github/workflows/publish-rubygem.yaml@main
+    secrets:
+      GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This makes use of the shared workflow that has been added to
alphagov/govuk-infrastructure which allows publishing rubygems.

Based on: https://github.com/alphagov/rubocop-govuk/pull/215