### PR TITLE
add support for remote port-forward connection to AmazonMQ web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+.byebug_history

--- a/spec/integration/amazonmq_spec.rb
+++ b/spec/integration/amazonmq_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "amazonmq" do
+  include SocketHelper
+  let(:cli) { GovukConnect::CLI.new }
+  before { disable_any_exec(cli) }
+
+  it "opens an remote port forward to publishingmq.(environment).govuk-internal.digital:443" do
+    stub_socket_port_free(32_768)
+    jumpbox = GovukConnect::CLI::JUMPBOXES.dig(:integration, :aws)
+
+    args = [
+      "ssh",
+      "-N",
+      "-L",
+      "32768:publishingmq.integration.govuk-internal.digital:443",
+      "test@#{jumpbox}",
+    ]
+
+    allow(cli).to receive(:exec).with(*args)
+    cli.main(["-e", "integration", "amazonmq"])
+  end
+end


### PR DESCRIPTION
As part of [this epic](https://trello.com/c/O8RFciiC/309-migrate-self-hosted-eol-rabbitmq-to-amazonmq), we're [adding an AmazonMQ broker](https://github.com/alphagov/govuk-aws/pull/1655) to replace the self-hosted RabbitMQ instances. There are a few quirks around connecting to it, so I've added support for a remote port-forward via the jumpbox, accessible with:

`govuk-connect -e integration amazonmq`

This will open a connection that allows you to access the https:// AmazonMQ web UI from localhost. Output is of the form:

```
You'll need to login as the RabbitMQ root user.
Get the password from govuk-aws-data, for example:

  # from the root directory of govuk-aws-data repository

  sops data/app-amazonmq/integration/common.secret.tfvars

Port forwarding setup, access:

  https://127.0.0.1:40807/

(ignore any warnings about certificate mis-match - this is expected and OK)
```