### PR TITLE
Use `.yml` for workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,6 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
       contents: write
-    uses: alphagov/govuk-infrastructure/.github/workflows/publish-rubygem.yaml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/publish-rubygem.yml@main
     secrets:
       GEM_HOST_API_KEY: ${{ secrets.ALPHAGOV_RUBYGEMS_API_KEY }}


### PR DESCRIPTION
This updates references to reusable workflows to use `.yml` instead of `.yaml` and updates the extension of any workflow files within this repsoitory. This is to make the extension used for YAML files consistent across the repository.
