### PR TITLE
Make the error message for sshing without VPN clearer

### DIFF
--- a/lib/govuk_connect/cli.rb
+++ b/lib/govuk_connect/cli.rb
@@ -113,6 +113,10 @@ class GovukConnect::CLI
     info "Check this is correct, and if it isn't, set the `USER` environment variable to the correct username."
   end
 
+  def print_vpn_help_info
+    info "You may also wish to check that you are connected to the VPN, as attempting to SSH into an instance when NOT on the VPN can result in an operation timed out error"
+  end
+
   # From Rosetta Code: https://rosettacode.org/wiki/Levenshtein_distance#Ruby
   def levenshtein_distance(string1, string2)
     string1 = string1.downcase
@@ -289,6 +293,8 @@ class GovukConnect::CLI
       error "\nerror: command failed: #{command}"
       print_empty_line
       print_ssh_username_configuration_help
+      print_empty_line
+      print_vpn_help_info
       exit 1
     end
 


### PR DESCRIPTION
Attempting to SSH into an instance when NOT on the VPN currently causes an obscure error message. It simply reads 'Operation timed out'. 

<img width="1086" alt="Screenshot 2023-01-06 at 15 04 52" src="https://user-images.githubusercontent.com/41922771/211042586-b5d4a685-94b6-4eb2-9724-178d601b014d.png">

It is not immediately obvious from this error what the problem is, so I have made a more descriptive error message.

![Screenshot 2023-01-06 at 16 02 12](https://user-images.githubusercontent.com/41922771/211050380-05730dbb-142d-4791-8db4-d764f373ad38.png)


[Trello](https://trello.com/c/oJAAsZoR/305-20-time-improve-error-messaging-around-govuk-connect)