### PR TITLE
Bump to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.1
+
+* Improve error messaging when not using VPN ([#83](https://github.com/alphagov/govuk-connect/pull/83))
+
 # 0.7.0
 
 * Drop support for Ruby 2.6

--- a/lib/govuk_connect/version.rb
+++ b/lib/govuk_connect/version.rb
@@ -1,3 +1,3 @@
 module GovukConnect
-  VERSION = "0.7.0".freeze
+  VERSION = "0.7.1".freeze
 end


### PR DESCRIPTION
Updating the gem version to reflect my recent changes to an error message in this [PR](https://github.com/alphagov/govuk-connect/pull/83).  